### PR TITLE
Add Metric spaces

### DIFF
--- a/src/Metric.ts
+++ b/src/Metric.ts
@@ -1,0 +1,89 @@
+/*
+ * A metric is a function that measures the distance between two values.
+ * The distance function should follow the laws of metrics:
+ * 1) Should follow the triangle inequality: distance(a)(b) + distance(b)(c) >= distance(a)(c)
+ * 2) Should be non-negative: distance(a)(b) >= 0
+ * 3) Should be idempotent: distance(a)(a) === 0
+ * 4) Should be symmetric: distance(a)(b) === distance(b)(a)
+ */
+
+import type * as order from "@fp-ts/core/typeclass/Order"
+
+import * as contravariant from "@fp-ts/core/typeclass/Contravariant"
+
+import type { TypeLambda } from "@fp-ts/core/HKT"
+
+import type * as invariant from "@fp-ts/core/typeclass/Invariant"
+
+/**
+ * @category models
+ * @since 1.0.0
+ */
+export interface Metric<A> {
+  distance: (that: A) => (self: A) => number
+}
+
+/**
+ * @category type lambdas
+ * @since 1.0.0
+ */
+export interface DistanceTypeLambda extends TypeLambda {
+  readonly type: Metric<this["Target"]>
+}
+
+/**
+ * @category constructors
+ * @since 1.0.0
+ */
+export const fromDistance = <A>(distance: Metric<A>["distance"]): Metric<A> => ({
+  distance
+})
+
+/**
+ * @category utils
+ * @since 1.0.0
+ */
+export const contramap = <B, A>(f: (b: B) => A) =>
+  (m: Metric<A>): Metric<B> => ({
+    distance: (that) => (self) => m.distance(f(that))(f(self))
+  })
+
+/**
+ * @category instances
+ * @since 1.0.0
+ */
+export const Contravariant: contravariant.Contravariant<DistanceTypeLambda> = contravariant.make(
+  contramap
+)
+
+/**
+ * @since 1.0.0
+ */
+export const imap: <A, B>(
+  to: (a: A) => B,
+  from: (b: B) => A
+) => (self: Metric<A>) => Metric<B> = Contravariant.imap
+
+/**
+ * @category instances
+ * @since 1.0.0
+ */
+export const Invariant: invariant.Invariant<DistanceTypeLambda> = {
+  imap
+}
+
+/**
+ * Given a metric, returns an order on A based on the distance from a center.
+ *
+ * @category utils
+ * @since 1.0.0
+ */
+export const getOrder = <A>(metric: Metric<A>) =>
+  (center: A): order.Order<A> => ({
+    compare: (that) =>
+      (self) => {
+        const dSelf = metric.distance(self)(center)
+        const dThat = metric.distance(that)(center)
+        return dSelf < dThat ? -1 : dSelf > dThat ? 1 : 0
+      }
+  })

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,6 +19,7 @@ import * as hashMap from "@fp-ts/data/HashMap"
 import * as hashSet from "@fp-ts/data/HashSet"
 import * as identity from "@fp-ts/data/Identity"
 import * as json from "@fp-ts/data/Json"
+import * as metric from "@fp-ts/data/Metric"
 import * as mutableHashMap from "@fp-ts/data/MutableHashMap"
 import * as mutableHashSet from "@fp-ts/data/MutableHashSet"
 import * as mutableList from "@fp-ts/data/MutableList"
@@ -129,6 +130,10 @@ export {
    * @since 1.0.0
    */
   json,
+  /**
+   * @since 1.0.0
+   */
+  metric,
   /**
    * @since 1.0.0
    */

--- a/test/Metric.ts
+++ b/test/Metric.ts
@@ -3,7 +3,7 @@ import * as U from "./util"
 
 // import { pipe } from "@fp-ts/data/Function"
 
-describe.concurrent("Duration", () => {
+describe.concurrent("Metric", () => {
   it("instances and derived exports", () => {
     expect(_.Contravariant).exist
     expect(_.contramap).exist

--- a/test/Metric.ts
+++ b/test/Metric.ts
@@ -1,0 +1,24 @@
+import * as _ from "@fp-ts/data/Metric"
+import * as U from "./util"
+
+// import { pipe } from "@fp-ts/data/Function"
+
+describe.concurrent("Duration", () => {
+  it("instances and derived exports", () => {
+    expect(_.Contravariant).exist
+    expect(_.contramap).exist
+    expect(_.Invariant).exist
+    expect(_.imap).exist
+  })
+
+  it("fromDistance", () => {
+    U.deepStrictEqual(_.fromDistance<number>((a) => (b) => Math.abs(a - b)).distance(-1)(1), 2)
+    U.deepStrictEqual(_.fromDistance<number>((a) => (b) => a === b ? 0 : 1).distance(0)(3), 1)
+  })
+
+  it("getOrder", () => {
+    const metrtic = _.fromDistance<number>((a) => (b) => Math.abs(a - b))
+    const order = _.getOrder(metrtic)(0)
+    U.deepStrictEqual(order.compare(1)(2), 1)
+  })
+})


### PR DESCRIPTION
Metric spaces are super useful. It would be a shame not to include them. Some use cases are:
- calculating distances between points(e.g. points on canvas)
- sorting a list of words by a search string (using e.g. levenshtein distance, etc.)
- sorting/grouping an array of objects by similarity