### PR TITLE
Leverage a Tag#id instead of Tag itself.

### DIFF
--- a/src/Context.ts
+++ b/src/Context.ts
@@ -18,6 +18,7 @@ export type TagTypeId = typeof TagTypeId
  * @category models
  */
 export interface Tag<Service> {
+  readonly id: {}
   readonly _id: TagTypeId
   readonly _S: (_: Service) => Service
 }
@@ -63,7 +64,7 @@ export interface Context<Services> extends Equal {
   readonly _id: TypeId
   readonly _S: (_: Services) => unknown
   /** @internal */
-  readonly unsafeMap: Map<Tag<any>, any>
+  readonly unsafeMap: Map<Tag<any>["id"], any>
 }
 
 /**

--- a/src/internal/Context.ts
+++ b/src/internal/Context.ts
@@ -10,7 +10,7 @@ export const TagTypeId: C.TagTypeId = Symbol.for("@fp-ts/data/Context/Tag") as C
 
 /** @internal */
 export class TagImpl<Service> implements C.Tag<Service> {
-  readonly id = {}
+  readonly id = this
   readonly _id: typeof TagTypeId = TagTypeId
   readonly _S: (_: Service) => Service = (_) => _
 

--- a/src/internal/Context.ts
+++ b/src/internal/Context.ts
@@ -10,6 +10,7 @@ export const TagTypeId: C.TagTypeId = Symbol.for("@fp-ts/data/Context/Tag") as C
 
 /** @internal */
 export class TagImpl<Service> implements C.Tag<Service> {
+  readonly id = {}
   readonly _id: typeof TagTypeId = TagTypeId
   readonly _S: (_: Service) => Service = (_) => _
 
@@ -54,7 +55,7 @@ export class ContextImpl<Services> implements C.Context<Services> {
     return Hash.number(this.unsafeMap.size)
   }
 
-  constructor(readonly unsafeMap: Map<C.Tag<any>, any>) {}
+  constructor(readonly unsafeMap: Map<C.Tag<any>["id"], any>) {}
 }
 
 /** @internal */
@@ -150,7 +151,7 @@ export const prune = <Services, S extends Array<C.Tags<Services>>>(...tags: S) =
   (self: C.Context<Services>): C.Context<
     { [k in keyof S]: C.Tag.Service<S[k]> }[number]
   > => {
-    const tagSet = new Set<C.Tag<any>>(tags)
+    const tagSet = new Set<C.Tag<any>["id"]>(tags)
     const newEnv = new Map()
     for (const [tag, s] of self.unsafeMap.entries()) {
       if (tagSet.has(tag)) {

--- a/src/internal/Context.ts
+++ b/src/internal/Context.ts
@@ -90,7 +90,7 @@ export const add = Dual.dual<
   ) => C.Context<Services | C.Tag.Service<T>>
 >(3, (self, tag, service) => {
   const map = new Map(self.unsafeMap)
-  map.set(tag, service)
+  map.set(tag.id, service)
   return new ContextImpl(map)
 })
 
@@ -106,10 +106,10 @@ export const get = Dual.dual<
     self: C.Context<Services>
   ) => T extends C.Tag<infer S> ? S : never
 >(2, (self, tag) => {
-  if (!self.unsafeMap.has(tag)) {
+  if (!self.unsafeMap.has(tag.id)) {
     throw new Error("Service not found")
   }
-  return self.unsafeMap.get(tag)!
+  return self.unsafeMap.get(tag.id)!
 })
 
 /** @internal */
@@ -117,10 +117,10 @@ export const unsafeGet = Dual.dual<
   <Services, S>(self: C.Context<Services>, tag: C.Tag<S>) => S,
   <S>(tag: C.Tag<S>) => <Services>(self: C.Context<Services>) => S
 >(2, (self, tag) => {
-  if (!self.unsafeMap.has(tag)) {
+  if (!self.unsafeMap.has(tag.id)) {
     throw new Error("Service not found")
   }
-  return self.unsafeMap.get(tag)!
+  return self.unsafeMap.get(tag.id)!
 })
 
 /** @internal */
@@ -128,10 +128,10 @@ export const getOption = Dual.dual<
   <Services, S>(self: C.Context<Services>, tag: C.Tag<S>) => O.Option<S>,
   <S>(tag: C.Tag<S>) => <Services>(self: C.Context<Services>) => O.Option<S>
 >(2, (self, tag) => {
-  if (!self.unsafeMap.has(tag)) {
+  if (!self.unsafeMap.has(tag.id)) {
     return option.none()
   }
-  return option.some(self.unsafeMap.get(tag)!)
+  return option.some(self.unsafeMap.get(tag.id)!)
 })
 
 /** @internal */

--- a/src/internal/Differ/ContextPatch.ts
+++ b/src/internal/Differ/ContextPatch.ts
@@ -61,7 +61,7 @@ export class AddService<Env, T> implements CP.ContextPatch<Env, Env | T> {
   readonly _id: CP.TypeId = ContextPatchTypeId
   readonly _Input: (_: Env) => void = variance
   readonly _Output: (_: never) => Env | T = variance
-  constructor(readonly tag: Tag<T>, readonly service: T) {}
+  constructor(readonly tag: Tag<T>["id"], readonly service: T) {}
 
   [Hash.symbol]() {
     return Hash.string(`ContextPatch(AddService)`)
@@ -81,7 +81,7 @@ export class RemoveService<Env, T> implements CP.ContextPatch<Env | T, Env> {
   readonly _id: CP.TypeId = ContextPatchTypeId
   readonly _Input: (_: Env | T) => void = variance
   readonly _Output: (_: never) => Env = variance
-  constructor(readonly tag: Tag<T>) {}
+  constructor(readonly tag: Tag<T>["id"]) {}
 
   [Hash.symbol]() {
     return Hash.string(`ContextPatch(RemoveService)`)
@@ -101,7 +101,7 @@ export class UpdateService<Env, T> implements CP.ContextPatch<Env | T, Env | T> 
   readonly _Input: (_: Env | T) => void = variance
   readonly _Output: (_: never) => Env | T = variance
   constructor(
-    readonly tag: Tag<T>,
+    readonly tag: Tag<T>["id"],
     readonly update: (service: T) => T
   ) {
   }
@@ -183,7 +183,7 @@ export const patch = Dual.dual<
   let patches: Chunk.Chunk<CP.ContextPatch<unknown, unknown>> = Chunk.of(
     self as CP.ContextPatch<unknown, unknown>
   )
-  const updatedContext: Map<Tag<unknown>, unknown> = new Map(context.unsafeMap)
+  const updatedContext: Map<Tag<unknown>["id"], unknown> = new Map(context.unsafeMap)
   while (Chunk.isNonEmpty(patches)) {
     const head: Instruction = Chunk.headNonEmpty(patches) as Instruction
     const tail = Chunk.tailNonEmpty(patches)


### PR DESCRIPTION
Suggesting to box the id of a Tag, so that the id becomes a value that can be shared/re-used,
so that other things can become valid Tags too (say, the static side of an (abstract) class), while static class constructor functions functions can still prepare inherited methods leveraging the tag (right now they can't because the instance itself is the Tag, and we don't have access to it because static constructors nor a concept of "thisConstructor" exist)