### PR TITLE
Allow empty case objects

### DIFF
--- a/.changeset/tall-seahorses-notice.md
+++ b/.changeset/tall-seahorses-notice.md
@@ -1,0 +1,5 @@
+---
+"@effect/data": patch
+---
+
+allow empty case objects

--- a/flake.nix
+++ b/flake.nix
@@ -31,6 +31,9 @@
           nodejs-16_x
           nodePackages.pnpm
         ];
+        shellHook = ''
+          pnpm install
+        '';
       };
     });
   };

--- a/src/Data.ts
+++ b/src/Data.ts
@@ -28,7 +28,7 @@ export declare namespace Case {
    * @category models
    */
   export interface Constructor<A extends Case, T extends keyof A = never> {
-    (args: Omit<A, T | keyof Equal.Equal>): A
+    (args: Omit<A, T | keyof Equal.Equal> extends Record<PropertyKey, never> ? void : Omit<A, T | keyof Equal.Equal>): A
   }
 }
 
@@ -102,7 +102,8 @@ export const array = <As extends ReadonlyArray<any>>(as: As): Data<As> => unsafe
  */
 export const unsafeArray = <As extends ReadonlyArray<any>>(as: As): Data<As> => Object.setPrototypeOf(as, protoArr)
 
-const _case = <A extends Case>(): Case.Constructor<A> => struct as any
+const _case = <A extends Case>(): Case.Constructor<A> =>
+  (args) => (args === undefined ? struct({}) : struct(args)) as any
 
 export {
   /**
@@ -124,7 +125,7 @@ export const tagged = <A extends Case & { _tag: string }>(
   tag: A["_tag"]
 ): Case.Constructor<A, "_tag"> =>
   // @ts-expect-error
-  (args) => struct({ _tag: tag, ...args })
+  (args) => args === undefined ? struct({}) : struct({ _tag: tag, ...args })
 
 /**
  * Provides a Tagged constructor for a Case Class.

--- a/test/Data.ts
+++ b/test/Data.ts
@@ -100,4 +100,17 @@ describe("Data", () => {
     expect(Equal.equals(a, b)).toBe(true)
     expect(Equal.equals(a, c)).toBe(false)
   })
+
+  it("tagged - empty", () => {
+    interface Person extends Data.Case {
+      readonly _tag: "Person"
+    }
+
+    const Person = Data.tagged<Person>("Person")
+
+    const a = Person()
+    const b = Person()
+
+    expect(Equal.equals(a, b)).toBe(true)
+  })
 })


### PR DESCRIPTION
Allows empty `Case` objects to be created. We should consider whether we really want this behavior.

```ts
interface Person extends Data.Case {
  readonly _tag: "Person"
}

const Person = Data.tagged<Person>("Person")

const person = Person()
```