### PR TITLE
feat: extend Duration type

### DIFF
--- a/.changeset/clean-shrimps-live.md
+++ b/.changeset/clean-shrimps-live.md
@@ -1,0 +1,5 @@
+---
+"@effect/data": patch
+---
+
+Duration - added typeclass implementations

--- a/docs/modules/Duration.ts.md
+++ b/docs/modules/Duration.ts.md
@@ -29,14 +29,25 @@ Added in v1.0.0
   - [zero](#zero)
 - [guards](#guards)
   - [isDuration](#isduration)
+- [instances](#instances)
+  - [Equivalence](#equivalence)
+  - [MonoidSum](#monoidsum)
+  - [Order](#order)
+  - [SemigroupMax](#semigroupmax)
+  - [SemigroupMin](#semigroupmin)
+  - [SemigroupSum](#semigroupsum)
 - [models](#models)
   - [Duration (interface)](#duration-interface)
 - [mutations](#mutations)
-  - [add](#add)
   - [subtract](#subtract)
+  - [sum](#sum)
+  - [sumAll](#sumall)
   - [times](#times)
 - [symbol](#symbol)
   - [TypeId (type alias)](#typeid-type-alias)
+- [utils](#utils)
+  - [max](#max)
+  - [min](#min)
 
 ---
 
@@ -201,6 +212,68 @@ export declare const isDuration: (u: unknown) => u is Duration
 
 Added in v1.0.0
 
+# instances
+
+## Equivalence
+
+**Signature**
+
+```ts
+export declare const Equivalence: equivalence.Equivalence<Duration>
+```
+
+Added in v1.0.0
+
+## MonoidSum
+
+**Signature**
+
+```ts
+export declare const MonoidSum: monoid.Monoid<Duration>
+```
+
+Added in v1.0.0
+
+## Order
+
+**Signature**
+
+```ts
+export declare const Order: order.Order<Duration>
+```
+
+Added in v1.0.0
+
+## SemigroupMax
+
+**Signature**
+
+```ts
+export declare const SemigroupMax: semigroup.Semigroup<Duration>
+```
+
+Added in v1.0.0
+
+## SemigroupMin
+
+**Signature**
+
+```ts
+export declare const SemigroupMin: semigroup.Semigroup<Duration>
+```
+
+Added in v1.0.0
+
+## SemigroupSum
+
+**Signature**
+
+```ts
+export declare const SemigroupSum: semigroup.Semigroup<Duration>
+```
+
+Added in v1.0.0
+
 # models
 
 ## Duration (interface)
@@ -218,16 +291,6 @@ Added in v1.0.0
 
 # mutations
 
-## add
-
-**Signature**
-
-```ts
-export declare const add: { (that: Duration): (self: Duration) => Duration; (self: Duration, that: Duration): Duration }
-```
-
-Added in v1.0.0
-
 ## subtract
 
 **Signature**
@@ -240,6 +303,26 @@ export declare const subtract: {
 ```
 
 Added in v1.0.0
+
+## sum
+
+**Signature**
+
+```ts
+export declare const sum: { (that: Duration): (self: Duration) => Duration; (self: Duration, that: Duration): Duration }
+```
+
+Added in v1.0.0
+
+## sumAll
+
+**Signature**
+
+```ts
+export declare const sumAll: (collection: Iterable<Duration>) => Duration
+```
+
+Added in v1.0.15
 
 ## times
 
@@ -259,6 +342,28 @@ Added in v1.0.0
 
 ```ts
 export type TypeId = typeof TypeId
+```
+
+Added in v1.0.0
+
+# utils
+
+## max
+
+**Signature**
+
+```ts
+export declare const max: { (that: Duration): (self: Duration) => Duration; (self: Duration, that: Duration): Duration }
+```
+
+Added in v1.0.0
+
+## min
+
+**Signature**
+
+```ts
+export declare const min: { (that: Duration): (self: Duration) => Duration; (self: Duration, that: Duration): Duration }
 ```
 
 Added in v1.0.0

--- a/src/Duration.ts
+++ b/src/Duration.ts
@@ -4,6 +4,11 @@
 import * as Equal from "@effect/data/Equal"
 import * as Dual from "@effect/data/Function"
 import * as Hash from "@effect/data/Hash"
+import type * as bounded from "@effect/data/typeclass/Bounded"
+import type * as equivalence from "@effect/data/typeclass/Equivalence"
+import * as monoid from "@effect/data/typeclass/Monoid"
+import * as order from "@effect/data/typeclass/Order"
+import * as semigroup from "@effect/data/typeclass/Semigroup"
 
 const TypeId: unique symbol = Symbol.for("@effect/data/Duration")
 
@@ -90,8 +95,70 @@ export const days = (days: number): Duration => new DurationImpl(days * 86_400_0
 export const weeks = (weeks: number): Duration => new DurationImpl(weeks * 604_800_000)
 
 /**
+ * @category instances
  * @since 1.0.0
- * @category mutations
+ */
+export const Order: order.Order<Duration> = {
+  compare: (self, that) => (self.millis < that.millis ? -1 : self.millis > that.millis ? 1 : 0)
+}
+
+/**
+ * @category instances
+ * @since 1.0.0
+ */
+export const Bounded: bounded.Bounded<Duration> = {
+  compare: Order.compare,
+  maxBound: infinity,
+  minBound: zero
+}
+
+/**
+ * Checks if a `Duration` is between a `minimum` and `maximum` value.
+ *
+ * @category predicates
+ * @since 1.0.0
+ */
+export const between: {
+  (minimum: Duration, maximum: Duration): (self: Duration) => boolean
+  (self: Duration, minimum: Duration, maximum: Duration): boolean
+} = order.between(Order)
+
+/**
+ * @category instances
+ * @since 1.0.0
+ */
+export const Equivalence: equivalence.Equivalence<Duration> = (self, that) => self.millis === that.millis
+
+/**
+ * @category utils
+ * @since 1.0.0
+ */
+export const min: {
+  (that: Duration): (self: Duration) => Duration
+  (self: Duration, that: Duration): Duration
+} = order.min(Order)
+
+/**
+ * @category utils
+ * @since 1.0.0
+ */
+export const max: {
+  (that: Duration): (self: Duration) => Duration
+  (self: Duration, that: Duration): Duration
+} = order.max(Order)
+
+/**
+ * @category utils
+ * @since 1.0.0
+ */
+export const clamp: {
+  (minimum: Duration, maximum: Duration): (self: Duration) => Duration
+  (self: Duration, minimum: Duration, maximum: Duration): Duration
+} = order.clamp(Order)
+
+/**
+ * @since 1.0.0
+ * @category math
  */
 export const times: {
   (times: number): (self: Duration) => Duration
@@ -103,9 +170,9 @@ export const times: {
 
 /**
  * @since 1.0.0
- * @category mutations
+ * @category math
  */
-export const add: {
+export const sum: {
   (that: Duration): (self: Duration) => Duration
   (self: Duration, that: Duration): Duration
 } = Dual.dual<
@@ -114,8 +181,50 @@ export const add: {
 >(2, (self, that) => new DurationImpl(self.millis + that.millis))
 
 /**
+ * @category instances
  * @since 1.0.0
- * @category mutations
+ */
+export const SemigroupSum: semigroup.Semigroup<Duration> = semigroup.make(sum)
+
+/**
+ * @category instances
+ * @since 1.0.0
+ */
+export const MonoidSum: monoid.Monoid<Duration> = monoid.fromSemigroup(SemigroupSum, zero)
+
+/**
+ * @category instances
+ * @since 1.0.0
+ */
+export const SemigroupMax: semigroup.Semigroup<Duration> = semigroup.make(max)
+
+/**
+ * @category instances
+ * @since 1.0.0
+ */
+export const MonoidMax: monoid.Monoid<Duration> = monoid.fromSemigroup(SemigroupMax, zero)
+
+/**
+ * @category instances
+ * @since 1.0.0
+ */
+export const SemigroupMin: semigroup.Semigroup<Duration> = semigroup.make(min)
+
+/**
+ * @category instances
+ * @since 1.0.0
+ */
+export const MonoidMin: monoid.Monoid<Duration> = monoid.fromSemigroup(SemigroupMin, infinity)
+
+/**
+ * @category math
+ * @since 1.0.15
+ */
+export const sumAll: (collection: Iterable<Duration>) => Duration = MonoidSum.combineAll
+
+/**
+ * @since 1.0.0
+ * @category math
  */
 export const subtract: {
   (that: Duration): (self: Duration) => Duration
@@ -127,7 +236,7 @@ export const subtract: {
 
 /**
  * @since 1.0.0
- * @category comparisons
+ * @category predicates
  */
 export const lessThan: {
   (that: Duration): (self: Duration) => boolean
@@ -139,7 +248,7 @@ export const lessThan: {
 
 /**
  * @since 1.0.0
- * @category comparisons
+ * @category predicates
  */
 export const lessThanOrEqualTo: {
   (self: Duration, that: Duration): boolean
@@ -151,7 +260,7 @@ export const lessThanOrEqualTo: {
 
 /**
  * @since 1.0.0
- * @category comparisons
+ * @category predicates
  */
 export const greaterThan: {
   (that: Duration): (self: Duration) => boolean
@@ -163,7 +272,7 @@ export const greaterThan: {
 
 /**
  * @since 1.0.0
- * @category comparisons
+ * @category predicates
  */
 export const greaterThanOrEqualTo: {
   (self: Duration, that: Duration): boolean
@@ -175,7 +284,7 @@ export const greaterThanOrEqualTo: {
 
 /**
  * @since 1.0.0
- * @category comparisons
+ * @category predicates
  */
 export const equals: {
   (that: Duration): (self: Duration) => boolean

--- a/test/Duration.ts
+++ b/test/Duration.ts
@@ -1,18 +1,127 @@
 import * as D from "@effect/data/Duration"
 import { pipe } from "@effect/data/Function"
+import { deepStrictEqual } from "@effect/data/test/util"
 
 describe.concurrent("Duration", () => {
+  it("exports", () => {
+    expect(D.Bounded).exist
+    expect(D.SemigroupSum).exist
+    expect(D.MonoidSum).exist
+    expect(D.SemigroupMin).exist
+    expect(D.MonoidMin).exist
+    expect(D.SemigroupMax).exist
+    expect(D.MonoidMax).exist
+    expect(D.Order).exist
+    expect(D.Equivalence).exist
+    expect(D.sum).exist
+    expect(D.sumAll).exist
+    expect(D.times).exist
+    expect(D.subtract).exist
+    expect(D.zero).exist
+    expect(D.millis).exist
+    expect(D.seconds).exist
+    expect(D.minutes).exist
+    expect(D.hours).exist
+    expect(D.days).exist
+    expect(D.weeks).exist
+    expect(D.infinity).exist
+    expect(D.between).exist
+    expect(D.lessThan).exist
+    expect(D.lessThanOrEqualTo).exist
+    expect(D.greaterThan).exist
+    expect(D.greaterThanOrEqualTo).exist
+    expect(D.clamp).exist
+    expect(D.max).exist
+    expect(D.min).exist
+  })
+
+  it("Order", () => {
+    deepStrictEqual(D.Order.compare(D.millis(1), D.millis(2)), -1)
+    deepStrictEqual(D.Order.compare(D.millis(2), D.millis(1)), 1)
+    deepStrictEqual(D.Order.compare(D.millis(2), D.millis(2)), 0)
+  })
+
+  it("Bounded", () => {
+    expect(D.Bounded.maxBound).toEqual(D.infinity)
+    expect(D.Bounded.minBound).toEqual(D.zero)
+  })
+
+  it("Equivalence", () => {
+    deepStrictEqual(D.Equivalence(D.millis(1), D.millis(1)), true)
+    deepStrictEqual(D.Equivalence(D.millis(1), D.millis(2)), false)
+    deepStrictEqual(D.Equivalence(D.millis(1), D.millis(2)), false)
+  })
+
+  it("SemigroupMax", () => {
+    deepStrictEqual(D.SemigroupMax.combine(D.millis(1), D.millis(2)), D.millis(2))
+    deepStrictEqual(D.SemigroupMax.combine(D.minutes(1), D.millis(2)), D.minutes(1))
+  })
+
+  it("MonoidMax", () => {
+    deepStrictEqual(D.MonoidMax.combine(D.millis(1), D.millis(2)), D.millis(2))
+    deepStrictEqual(D.MonoidMax.combine(D.minutes(1), D.MonoidMax.empty), D.minutes(1))
+  })
+
+  it("SemigroupMin", () => {
+    deepStrictEqual(D.SemigroupMin.combine(D.millis(1), D.millis(2)), D.millis(1))
+    deepStrictEqual(D.SemigroupMin.combine(D.minutes(1), D.millis(2)), D.millis(2))
+  })
+
+  it("MonoidMin", () => {
+    deepStrictEqual(D.MonoidMin.combine(D.millis(1), D.millis(2)), D.millis(1))
+    deepStrictEqual(D.MonoidMin.combine(D.minutes(1), D.MonoidMin.empty), D.minutes(1))
+  })
+
+  it("SemigroupSum", () => {
+    deepStrictEqual(D.SemigroupSum.combine(D.seconds(30), D.seconds(30)), D.minutes(1))
+    deepStrictEqual(D.SemigroupSum.combine(D.millis(999), D.millis(1)), D.seconds(1))
+  })
+
+  it("MonoidSum", () => {
+    deepStrictEqual(D.MonoidSum.combine(D.seconds(30), D.seconds(30)), D.minutes(1))
+    deepStrictEqual(D.MonoidSum.combine(D.minutes(1), D.MonoidSum.empty), D.minutes(1))
+  })
+
+  it("max", () => {
+    deepStrictEqual(D.max(D.millis(1), D.millis(2)), D.millis(2))
+    deepStrictEqual(D.max(D.minutes(1), D.millis(2)), D.minutes(1))
+  })
+
+  it("min", () => {
+    deepStrictEqual(D.min(D.millis(1), D.millis(2)), D.millis(1))
+    deepStrictEqual(D.min(D.minutes(1), D.millis(2)), D.millis(2))
+  })
+
+  it("clamp", () => {
+    deepStrictEqual(D.clamp(D.millis(1), D.millis(2), D.millis(3)), D.millis(2))
+    deepStrictEqual(D.clamp(D.minutes(1.5), D.minutes(1), D.minutes(2)), D.minutes(1.5))
+  })
+
   it("equals", () => {
     assert.isTrue(pipe(D.hours(1), D.equals(D.minutes(60))))
   })
+
+  it("between", () => {
+    assert.isTrue(D.between(D.hours(1), D.minutes(59), D.minutes(61)))
+    assert.isTrue(D.between(D.minutes(1), D.seconds(59), D.seconds(61)))
+  })
+
   it("times", () => {
     assert.isTrue(
       pipe(D.minutes(1), D.equals(pipe(D.seconds(1), D.times(60))))
     )
   })
-  it("add", () => {
+  it("sum", () => {
     assert.isTrue(
-      pipe(D.minutes(1), D.equals(pipe(D.seconds(30), D.add(D.seconds(30)))))
+      pipe(D.minutes(1), D.equals(pipe(D.seconds(30), D.sum(D.seconds(30)))))
+    )
+  })
+  it("sumAll", () => {
+    assert.isTrue(
+      D.equals(
+        D.sumAll([D.seconds(30), D.seconds(15), D.seconds(15)]),
+        D.minutes(1)
+      )
     )
   })
   it(">", () => {


### PR DESCRIPTION
Extended Duration module to include: Order, Equivalence, MonoidSum, SemigroupMax, SemigroupMin, SemigroupSum, min, max, sumAll and renamed add to sum to keep names consistent with Number and Bigint modules. 

I considered adding a Bounded type but I'm not sure what the lower bound would be. Zero makes sense as a lower bound for a duration but I don't know if it makes sense to enforce that in a Bounded type or if -Infinity makes more sense. 

