### PR TITLE
fix(Chunk): avoid out-of-memory in copyToArray

### DIFF
--- a/.changeset/thirty-monkeys-rest.md
+++ b/.changeset/thirty-monkeys-rest.md
@@ -1,0 +1,5 @@
+---
+"@effect/data": patch
+---
+
+Fix Chunk out-of-memory issues

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -385,20 +385,21 @@ const copyToArray = <A>(self: Chunk<A>, array: Array<any>, initial: number): voi
   const toProcess: Array<[Chunk<any>, number]> = [[self, initial]]
 
   while (toProcess.length > 0) {
-    const [chunk, n] = toProcess.shift()!
+    const [chunk, n] = toProcess.pop()!
 
     switch (chunk.backing._tag) {
       case "IArray": {
         copy(chunk.backing.array, 0, array, n, chunk.length)
-        continue
+        break
       }
       case "IConcat": {
-        toProcess.push([chunk.left, n])
         toProcess.push([chunk.right, n + chunk.left.length])
-        continue
+        toProcess.push([chunk.left, n])
+        break
       }
       case "ISingleton": {
         array[n] = chunk.backing.a
+        break
       }
     }
   }

--- a/src/Chunk.ts
+++ b/src/Chunk.ts
@@ -381,20 +381,25 @@ class ChunkImpl<A> implements Chunk<A> {
 }
 
 /** @internal */
-const copyToArray = <A>(self: Chunk<A>, array: Array<any>, n: number) => {
-  switch (self.backing._tag) {
-    case "IArray": {
-      copy(self.backing.array, 0, array, n, self.length)
-      break
-    }
-    case "IConcat": {
-      copyToArray(self.left, array, n)
-      copyToArray(self.right, array, n + self.left.length)
-      break
-    }
-    case "ISingleton": {
-      array[n] = self.backing.a
-      break
+const copyToArray = <A>(self: Chunk<A>, array: Array<any>, initial: number): void => {
+  const toProcess: Array<[Chunk<any>, number]> = [[self, initial]]
+
+  while (toProcess.length > 0) {
+    const [chunk, n] = toProcess.shift()!
+
+    switch (chunk.backing._tag) {
+      case "IArray": {
+        copy(chunk.backing.array, 0, array, n, chunk.length)
+        continue
+      }
+      case "IConcat": {
+        toProcess.push([chunk.left, n])
+        toProcess.push([chunk.right, n + chunk.left.length])
+        continue
+      }
+      case "ISingleton": {
+        array[n] = chunk.backing.a
+      }
     }
   }
 }

--- a/test/Chunk.ts
+++ b/test/Chunk.ts
@@ -2,6 +2,7 @@ import * as C from "@effect/data/Chunk"
 import { equals } from "@effect/data/Equal"
 import { pipe } from "@effect/data/Function"
 import * as O from "@effect/data/Option"
+import * as RA from "@effect/data/ReadonlyArray"
 import * as fc from "fast-check"
 import { inspect } from "node:util"
 
@@ -78,6 +79,17 @@ describe.concurrent("Chunk", () => {
       const chunk = C.empty()
       it("should give back an empty readonly array", () => {
         expect(C.toReadonlyArray(chunk)).toEqual([])
+      })
+    })
+
+    describe.concurrent("Given a large Chunk", () => {
+      const len = 100_000
+      let chunk = C.empty<number>()
+      for (let i = 0; i < len; i++) chunk = C.of(i).concat(chunk)
+
+      it("gives back a readonly array", () => {
+        expect(() => C.toReadonlyArray(chunk)).not.toThrow()
+        expect(C.toReadonlyArray(chunk)).toEqual(RA.reverse(RA.range(0, len - 1)))
       })
     })
   })


### PR DESCRIPTION
Avoids recursion in `copyToArray` to avoid out-of-memory issues with larger chunks concatenated in "just the right way".

Adds a test case for ensuring it works with a previously failing example.