### PR TITLE
Align Do, unit, let, bind, letDiscard, bindDiscard

### DIFF
--- a/.changeset/young-meals-invent.md
+++ b/.changeset/young-meals-invent.md
@@ -1,0 +1,5 @@
+---
+"@effect/data": minor
+---
+
+Align Do, unit, let, bind, letDiscard, bindDiscard

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -40,11 +40,12 @@ Added in v1.0.0
   - [inspectRight](#inspectright)
 - [do notation](#do-notation)
   - [Do](#do)
-  - [andThenBind](#andthenbind)
   - [appendElement](#appendelement)
   - [bind](#bind)
+  - [bindDiscard](#binddiscard)
   - [bindTo](#bindto)
   - [let](#let)
+  - [letDiscard](#letdiscard)
   - [tupled](#tupled)
 - [equivalence](#equivalence)
   - [getEquivalence](#getequivalence)
@@ -538,45 +539,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const Do: Either<never, {}>
-```
-
-Added in v1.0.0
-
-## andThenBind
-
-Extends the `Either` value with the value of another `Either` type.
-
-If both `Either` instances are `Left`, then the result will be the first `Left`.
-
-**Signature**
-
-```ts
-export declare const andThenBind: {
-  <N extends string, A extends object, E2, B>(name: Exclude<N, keyof A>, that: Either<E2, B>): <E1>(
-    self: Either<E1, A>
-  ) => Either<E2 | E1, { [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-  <E1, A extends object, N extends string, E2, B>(
-    self: Either<E1, A>,
-    name: Exclude<N, keyof A>,
-    that: Either<E2, B>
-  ): Either<E1 | E2, { [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-}
-```
-
-**Example**
-
-```ts
-import * as E from '@effect/data/Either'
-import { pipe } from '@effect/data/Function'
-
-const result = pipe(
-  E.Do,
-  E.bind('a', () => E.left('e1')),
-  E.andThenBind('b', E.left('e2'))
-)
-
-assert.deepStrictEqual(result, E.left('e1'))
+export declare const Do: <E = never>() => Either<E, {}>
 ```
 
 Added in v1.0.0
@@ -615,6 +578,44 @@ export declare const bind: {
 
 Added in v1.0.0
 
+## bindDiscard
+
+Extends the `Either` value with the value of another `Either` type.
+
+If both `Either` instances are `Left`, then the result will be the first `Left`.
+
+**Signature**
+
+```ts
+export declare const bindDiscard: {
+  <N extends string, A extends object, E2, B>(name: Exclude<N, keyof A>, that: Either<E2, B>): <E1>(
+    self: Either<E1, A>
+  ) => Either<E2 | E1, { [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+  <E1, A extends object, N extends string, E2, B>(
+    self: Either<E1, A>,
+    name: Exclude<N, keyof A>,
+    that: Either<E2, B>
+  ): Either<E1 | E2, { [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+}
+```
+
+**Example**
+
+```ts
+import * as E from '@effect/data/Either'
+import { pipe } from '@effect/data/Function'
+
+const result = pipe(
+  E.Do(),
+  E.bind('a', () => E.left('e1')),
+  E.bindDiscard('b', E.left('e2'))
+)
+
+assert.deepStrictEqual(result, E.left('e1'))
+```
+
+Added in v1.0.0
+
 ## bindTo
 
 **Signature**
@@ -638,6 +639,24 @@ export declare const let: {
     self: Either<E, A>
   ) => Either<E, { [K in N | keyof A]: K extends keyof A ? A[K] : B }>
   <E, A extends object, N extends string, B>(self: Either<E, A>, name: Exclude<N, keyof A>, f: (a: A) => B): Either<
+    E,
+    { [K in N | keyof A]: K extends keyof A ? A[K] : B }
+  >
+}
+```
+
+Added in v1.0.0
+
+## letDiscard
+
+**Signature**
+
+```ts
+export declare const letDiscard: {
+  <N extends string, A extends object, B>(name: Exclude<N, keyof A>, b: B): <E>(
+    self: Either<E, A>
+  ) => Either<E, { [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+  <E, A extends object, N extends string, B>(self: Either<E, A>, name: Exclude<N, keyof A>, b: B): Either<
     E,
     { [K in N | keyof A]: K extends keyof A ? A[K] : B }
   >
@@ -1809,7 +1828,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const unit: Either<never, void>
+export declare const unit: <E = never>() => Either<E, void>
 ```
 
 Added in v1.0.0

--- a/docs/modules/Identity.ts.md
+++ b/docs/modules/Identity.ts.md
@@ -14,10 +14,11 @@ Added in v1.0.0
 
 - [do notation](#do-notation)
   - [Do](#do)
-  - [andThenBind](#andthenbind)
   - [bind](#bind)
+  - [bindDiscard](#binddiscard)
   - [bindTo](#bindto)
   - [let](#let)
+  - [letDiscard](#letdiscard)
 - [instances](#instances)
   - [Applicative](#applicative)
   - [Chainable](#chainable)
@@ -54,25 +55,6 @@ export declare const Do: {}
 
 Added in v1.0.0
 
-## andThenBind
-
-A variant of `bind` that sequentially ignores the scope.
-
-**Signature**
-
-```ts
-export declare const andThenBind: {
-  <N extends string, A extends object, B>(name: Exclude<N, keyof A>, that: B): (self: A) => {
-    [K in N | keyof A]: K extends keyof A ? A[K] : B
-  }
-  <A extends object, N extends string, B>(self: A, name: Exclude<N, keyof A>, that: B): {
-    [K in N | keyof A]: K extends keyof A ? A[K] : B
-  }
-}
-```
-
-Added in v1.0.0
-
 ## bind
 
 **Signature**
@@ -83,6 +65,25 @@ export declare const bind: {
     [K in N | keyof A]: K extends keyof A ? A[K] : B
   }
   <A extends object, N extends string, B>(self: A, name: Exclude<N, keyof A>, f: (a: A) => B): {
+    [K in N | keyof A]: K extends keyof A ? A[K] : B
+  }
+}
+```
+
+Added in v1.0.0
+
+## bindDiscard
+
+A variant of `bind` that sequentially ignores the scope.
+
+**Signature**
+
+```ts
+export declare const bindDiscard: {
+  <N extends string, A extends object, B>(name: Exclude<N, keyof A>, that: B): (self: A) => {
+    [K in N | keyof A]: K extends keyof A ? A[K] : B
+  }
+  <A extends object, N extends string, B>(self: A, name: Exclude<N, keyof A>, that: B): {
     [K in N | keyof A]: K extends keyof A ? A[K] : B
   }
 }
@@ -113,6 +114,23 @@ export declare const let: {
     [K in N | keyof A]: K extends keyof A ? A[K] : B
   }
   <A extends object, N extends string, B>(self: A, name: Exclude<N, keyof A>, f: (a: A) => B): {
+    [K in N | keyof A]: K extends keyof A ? A[K] : B
+  }
+}
+```
+
+Added in v1.0.0
+
+## letDiscard
+
+**Signature**
+
+```ts
+export declare const letDiscard: {
+  <N extends string, A extends object, B>(name: Exclude<N, keyof A>, b: B): (self: A) => {
+    [K in N | keyof A]: K extends keyof A ? A[K] : B
+  }
+  <A extends object, N extends string, B>(self: A, name: Exclude<N, keyof A>, b: B): {
     [K in N | keyof A]: K extends keyof A ? A[K] : B
   }
 }

--- a/docs/modules/Option.ts.md
+++ b/docs/modules/Option.ts.md
@@ -45,11 +45,12 @@ Added in v1.0.0
   - [inspectSome](#inspectsome)
 - [do notation](#do-notation)
   - [Do](#do)
-  - [andThenBind](#andthenbind)
   - [appendElement](#appendelement)
   - [bind](#bind)
+  - [bindDiscard](#binddiscard)
   - [bindTo](#bindto)
   - [let](#let)
+  - [letDiscard](#letdiscard)
   - [tupled](#tupled)
 - [equivalence](#equivalence)
   - [getEquivalence](#getequivalence)
@@ -742,26 +743,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const Do: Option<{}>
-```
-
-Added in v1.0.0
-
-## andThenBind
-
-A variant of `bind` that sequentially ignores the scope.
-
-**Signature**
-
-```ts
-export declare const andThenBind: {
-  <N extends string, A extends object, B>(name: Exclude<N, keyof A>, that: Option<B>): (
-    self: Option<A>
-  ) => Option<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-  <A extends object, N extends string, B>(self: Option<A>, name: Exclude<N, keyof A>, that: Option<B>): Option<{
-    [K in N | keyof A]: K extends keyof A ? A[K] : B
-  }>
-}
+export declare const Do: () => Option<{}>
 ```
 
 Added in v1.0.0
@@ -807,6 +789,25 @@ export declare const bind: {
 
 Added in v1.0.0
 
+## bindDiscard
+
+A variant of `bind` that sequentially ignores the scope.
+
+**Signature**
+
+```ts
+export declare const bindDiscard: {
+  <N extends string, A extends object, B>(name: Exclude<N, keyof A>, that: Option<B>): (
+    self: Option<A>
+  ) => Option<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+  <A extends object, N extends string, B>(self: Option<A>, name: Exclude<N, keyof A>, that: Option<B>): Option<{
+    [K in N | keyof A]: K extends keyof A ? A[K] : B
+  }>
+}
+```
+
+Added in v1.0.0
+
 ## bindTo
 
 **Signature**
@@ -830,6 +831,23 @@ export declare const let: {
     self: Option<A>
   ) => Option<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }>
   <A extends object, N extends string, B>(self: Option<A>, name: Exclude<N, keyof A>, f: (a: A) => B): Option<{
+    [K in N | keyof A]: K extends keyof A ? A[K] : B
+  }>
+}
+```
+
+Added in v1.0.0
+
+## letDiscard
+
+**Signature**
+
+```ts
+export declare const letDiscard: {
+  <N extends string, A extends object, B>(name: Exclude<N, keyof A>, b: B): (
+    self: Option<A>
+  ) => Option<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+  <A extends object, N extends string, B>(self: Option<A>, name: Exclude<N, keyof A>, b: B): Option<{
     [K in N | keyof A]: K extends keyof A ? A[K] : B
   }>
 }
@@ -2051,7 +2069,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const unit: Option<void>
+export declare const unit: () => Option<void>
 ```
 
 Added in v1.0.0

--- a/docs/modules/Predicate.ts.md
+++ b/docs/modules/Predicate.ts.md
@@ -25,7 +25,7 @@ Added in v1.0.0
   - [contramap](#contramap)
 - [do notation](#do-notation)
   - [Do](#do)
-  - [andThenBind](#andthenbind)
+  - [bindDiscard](#binddiscard)
   - [bindTo](#bindto)
 - [guards](#guards)
   - [isBigint](#isbigint)
@@ -264,19 +264,19 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const Do: Predicate<{}>
+export declare const Do: () => Predicate<{}>
 ```
 
 Added in v1.0.0
 
-## andThenBind
+## bindDiscard
 
 A variant of `bind` that sequentially ignores the scope.
 
 **Signature**
 
 ```ts
-export declare const andThenBind: {
+export declare const bindDiscard: {
   <N extends string, A extends object, B>(name: Exclude<N, keyof A>, that: Predicate<B>): (
     self: Predicate<A>
   ) => Predicate<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>

--- a/docs/modules/ReadonlyArray.ts.md
+++ b/docs/modules/ReadonlyArray.ts.md
@@ -36,10 +36,11 @@ Added in v1.0.0
   - [fromRecord](#fromrecord)
 - [do notation](#do-notation)
   - [Do](#do)
-  - [andThenBind](#andthenbind)
   - [bind](#bind)
+  - [bindDiscard](#binddiscard)
   - [bindTo](#bindto)
   - [let](#let)
+  - [letDiscard](#letdiscard)
 - [filtering](#filtering)
   - [compact](#compact)
   - [filter](#filter)
@@ -459,26 +460,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const Do: readonly {}[]
-```
-
-Added in v1.0.0
-
-## andThenBind
-
-A variant of `bind` that sequentially ignores the scope.
-
-**Signature**
-
-```ts
-export declare const andThenBind: {
-  <N extends string, A extends object, B>(name: Exclude<N, keyof A>, that: readonly B[]): (
-    self: readonly A[]
-  ) => { [K in N | keyof A]: K extends keyof A ? A[K] : B }[]
-  <A extends object, N extends string, B>(self: readonly A[], name: Exclude<N, keyof A>, that: readonly B[]): {
-    [K in N | keyof A]: K extends keyof A ? A[K] : B
-  }[]
-}
+export declare const Do: () => ReadonlyArray<{}>
 ```
 
 Added in v1.0.0
@@ -493,6 +475,25 @@ export declare const bind: {
     self: readonly A[]
   ) => { [K in N | keyof A]: K extends keyof A ? A[K] : B }[]
   <A extends object, N extends string, B>(self: readonly A[], name: Exclude<N, keyof A>, f: (a: A) => readonly B[]): {
+    [K in N | keyof A]: K extends keyof A ? A[K] : B
+  }[]
+}
+```
+
+Added in v1.0.0
+
+## bindDiscard
+
+A variant of `bind` that sequentially ignores the scope.
+
+**Signature**
+
+```ts
+export declare const bindDiscard: {
+  <N extends string, A extends object, B>(name: Exclude<N, keyof A>, that: readonly B[]): (
+    self: readonly A[]
+  ) => { [K in N | keyof A]: K extends keyof A ? A[K] : B }[]
+  <A extends object, N extends string, B>(self: readonly A[], name: Exclude<N, keyof A>, that: readonly B[]): {
     [K in N | keyof A]: K extends keyof A ? A[K] : B
   }[]
 }
@@ -523,6 +524,23 @@ export declare const let: {
     self: readonly A[]
   ) => { [K in N | keyof A]: K extends keyof A ? A[K] : B }[]
   <A extends object, N extends string, B>(self: readonly A[], name: Exclude<N, keyof A>, f: (a: A) => B): {
+    [K in N | keyof A]: K extends keyof A ? A[K] : B
+  }[]
+}
+```
+
+Added in v1.0.0
+
+## letDiscard
+
+**Signature**
+
+```ts
+export declare const letDiscard: {
+  <N extends string, A extends object, B>(name: Exclude<N, keyof A>, b: B): (
+    self: readonly A[]
+  ) => { [K in N | keyof A]: K extends keyof A ? A[K] : B }[]
+  <A extends object, N extends string, B>(self: readonly A[], name: Exclude<N, keyof A>, b: B): {
     [K in N | keyof A]: K extends keyof A ? A[K] : B
   }[]
 }

--- a/docs/modules/typeclass/Covariant.ts.md
+++ b/docs/modules/typeclass/Covariant.ts.md
@@ -14,6 +14,7 @@ Added in v1.0.0
 
 - [do notation](#do-notation)
   - [let](#let)
+  - [letDiscard](#letdiscard)
 - [mapping](#mapping)
   - [as](#as)
   - [asUnit](#asunit)
@@ -44,6 +45,29 @@ export declare const let: <F extends TypeLambda>(
     name: Exclude<N, keyof A>,
     f: (a: A) => B
   ): Kind<F, R, O, E, { [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+}
+```
+
+Added in v1.0.0
+
+## letDiscard
+
+**Signature**
+
+```ts
+export declare const letDiscard: <F extends TypeLambda>(
+  F: Covariant<F>
+) => {
+  <N extends string, A extends object, B>(name: Exclude<N, keyof A>, b: B): <R, O, E>(
+    self: Kind<F, R, O, E, A>
+  ) => Kind<F, R, O, E, { [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+  <R, O, E, A extends object, N extends string, B>(self: Kind<F, R, O, E, A>, name: Exclude<N, keyof A>, b: B): Kind<
+    F,
+    R,
+    O,
+    E,
+    { [K in N | keyof A]: K extends keyof A ? A[K] : B }
+  >
 }
 ```
 

--- a/docs/modules/typeclass/Of.ts.md
+++ b/docs/modules/typeclass/Of.ts.md
@@ -29,7 +29,9 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const Do: <F extends TypeLambda>(F: Of<F>) => Kind<F, unknown, never, never, {}>
+export declare const Do: <F extends TypeLambda>(
+  F: Of<F>
+) => <R = unknown, O = never, E = never>() => Kind<F, R, O, E, {}>
 ```
 
 Added in v1.0.0
@@ -70,7 +72,9 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const unit: <F extends TypeLambda>(F: Of<F>) => Kind<F, unknown, never, never, void>
+export declare const unit: <F extends TypeLambda>(
+  F: Of<F>
+) => <R = unknown, O = never, E = never>() => Kind<F, R, O, E, void>
 ```
 
 Added in v1.0.0

--- a/docs/modules/typeclass/SemiProduct.ts.md
+++ b/docs/modules/typeclass/SemiProduct.ts.md
@@ -15,7 +15,7 @@ Added in v1.0.0
 - [constructors](#constructors)
   - [productMany](#productmany)
 - [do notation](#do-notation)
-  - [andThenBind](#andthenbind)
+  - [bindDiscard](#binddiscard)
 - [type class](#type-class)
   - [SemiProduct (interface)](#semiproduct-interface)
 - [utils](#utils)
@@ -52,12 +52,12 @@ Added in v1.0.0
 
 # do notation
 
-## andThenBind
+## bindDiscard
 
 **Signature**
 
 ```ts
-export declare const andThenBind: <F extends TypeLambda>(
+export declare const bindDiscard: <F extends TypeLambda>(
   F: SemiProduct<F>
 ) => {
   <N extends string, A extends object, R2, O2, E2, B>(name: Exclude<N, keyof A>, that: Kind<F, R2, O2, E2, B>): <

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -358,7 +358,7 @@ const Of: of_.Of<EitherTypeLambda> = {
 /**
  * @since 1.0.0
  */
-export const unit: Either<never, void> = of_.unit(Of)
+export const unit: <E = never>() => Either<E, void> = of_.unit(Of)
 
 /**
  * @category instances
@@ -1459,11 +1459,28 @@ export {
    */
   let_ as let
 }
+
 /**
  * @category do notation
  * @since 1.0.0
  */
-export const Do: Either<never, {}> = of_.Do(Of)
+export const letDiscard: {
+  <N extends string, A extends object, B>(
+    name: Exclude<N, keyof A>,
+    b: B
+  ): <E>(self: Either<E, A>) => Either<E, { [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+  <E, A extends object, N extends string, B>(
+    self: Either<E, A>,
+    name: Exclude<N, keyof A>,
+    b: B
+  ): Either<E, { [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+} = covariant.letDiscard(Covariant)
+
+/**
+ * @category do notation
+ * @since 1.0.0
+ */
+export const Do: <E = never>() => Either<E, {}> = of_.Do(Of)
 
 /**
  * @category do notation
@@ -1497,9 +1514,9 @@ export const bind: {
  * import { pipe } from '@effect/data/Function'
  *
  * const result = pipe(
- *   E.Do,
+ *   E.Do(),
  *   E.bind("a", () => E.left("e1")),
- *   E.andThenBind("b", E.left("e2"))
+ *   E.bindDiscard("b", E.left("e2"))
  * )
  *
  * assert.deepStrictEqual(result, E.left("e1"))
@@ -1507,7 +1524,7 @@ export const bind: {
  * @category do notation
  * @since 1.0.0
  */
-export const andThenBind: {
+export const bindDiscard: {
   <N extends string, A extends object, E2, B>(
     name: Exclude<N, keyof A>,
     that: Either<E2, B>
@@ -1519,7 +1536,7 @@ export const andThenBind: {
     name: Exclude<N, keyof A>,
     that: Either<E2, B>
   ): Either<E1 | E2, { [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-} = semiProduct.andThenBind(SemiProduct)
+} = semiProduct.bindDiscard(SemiProduct)
 
 /**
  * The `gen` API is a helper function that provides a generator interface for the `Either` monad instance.

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -285,7 +285,7 @@ export const bind: {
  * @category do notation
  * @since 1.0.0
  */
-export const andThenBind: {
+export const bindDiscard: {
   <N extends string, A extends object, B>(
     name: Exclude<N, keyof A>,
     that: Identity<B>
@@ -295,4 +295,20 @@ export const andThenBind: {
     name: Exclude<N, keyof A>,
     that: Identity<B>
   ): Identity<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-} = semiProduct.andThenBind(SemiProduct)
+} = semiProduct.bindDiscard(SemiProduct)
+
+/**
+ * @category do notation
+ * @since 1.0.0
+ */
+export const letDiscard: {
+  <N extends string, A extends object, B>(
+    name: Exclude<N, keyof A>,
+    b: B
+  ): (self: A) => { [K in N | keyof A]: K extends keyof A ? A[K] : B }
+  <A extends object, N extends string, B>(
+    self: A,
+    name: Exclude<N, keyof A>,
+    b: B
+  ): { [K in N | keyof A]: K extends keyof A ? A[K] : B }
+} = covariant.letDiscard(Chainable)

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -672,7 +672,7 @@ const Of: of_.Of<OptionTypeLambda> = {
 /**
  * @since 1.0.0
  */
-export const unit: Option<void> = of_.unit(Of)
+export const unit: () => Option<void> = of_.unit(Of)
 
 /**
  * @since 1.0.0
@@ -1706,6 +1706,22 @@ export {
  * @category do notation
  * @since 1.0.0
  */
+export const letDiscard: {
+  <N extends string, A extends object, B>(
+    name: Exclude<N, keyof A>,
+    b: B
+  ): (self: Option<A>) => Option<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+  <A extends object, N extends string, B>(
+    self: Option<A>,
+    name: Exclude<N, keyof A>,
+    b: B
+  ): Option<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+} = covariant.letDiscard(Covariant)
+
+/**
+ * @category do notation
+ * @since 1.0.0
+ */
 export const bind: {
   <N extends string, A extends object, B>(
     name: Exclude<N, keyof A>,
@@ -1722,7 +1738,7 @@ export const bind: {
  * @category do notation
  * @since 1.0.0
  */
-export const Do: Option<{}> = of_.Do(Of)
+export const Do: () => Option<{}> = of_.Do(Of)
 
 /**
  * A variant of `bind` that sequentially ignores the scope.
@@ -1730,7 +1746,7 @@ export const Do: Option<{}> = of_.Do(Of)
  * @category do notation
  * @since 1.0.0
  */
-export const andThenBind: {
+export const bindDiscard: {
   <N extends string, A extends object, B>(
     name: Exclude<N, keyof A>,
     that: Option<B>
@@ -1740,7 +1756,7 @@ export const andThenBind: {
     name: Exclude<N, keyof A>,
     that: Option<B>
   ): Option<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-} = semiProduct.andThenBind(SemiProduct)
+} = semiProduct.bindDiscard(SemiProduct)
 
 /**
  * The `gen` API is a helper function that provides a generator interface for the `Option` monad instance.

--- a/src/Predicate.ts
+++ b/src/Predicate.ts
@@ -775,7 +775,7 @@ export const bindTo: {
  * @category do notation
  * @since 1.0.0
  */
-export const Do: Predicate<{}> = of_.Do(Of)
+export const Do: () => Predicate<{}> = of_.Do(Of)
 
 /**
  * A variant of `bind` that sequentially ignores the scope.
@@ -783,7 +783,7 @@ export const Do: Predicate<{}> = of_.Do(Of)
  * @category do notation
  * @since 1.0.0
  */
-export const andThenBind: {
+export const bindDiscard: {
   <N extends string, A extends object, B>(
     name: Exclude<N, keyof A>,
     that: Predicate<B>
@@ -795,4 +795,4 @@ export const andThenBind: {
     name: Exclude<N, keyof A>,
     that: Predicate<B>
   ): Predicate<{ readonly [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-} = semiProduct.andThenBind(SemiProduct)
+} = semiProduct.bindDiscard(SemiProduct)

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -2383,7 +2383,23 @@ export {
  * @category do notation
  * @since 1.0.0
  */
-export const Do: ReadonlyArray<{}> = of_.Do(Of)
+export const letDiscard: {
+  <N extends string, A extends object, B>(
+    name: Exclude<N, keyof A>,
+    b: B
+  ): (self: ReadonlyArray<A>) => Array<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+  <A extends object, N extends string, B>(
+    self: ReadonlyArray<A>,
+    name: Exclude<N, keyof A>,
+    b: B
+  ): Array<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }>
+} = covariant.letDiscard(Covariant) as any
+
+/**
+ * @category do notation
+ * @since 1.0.0
+ */
+export const Do: () => ReadonlyArray<{}> = of_.Do(Of)
 
 /**
  * @category do notation
@@ -2407,7 +2423,7 @@ export const bind: {
  * @category do notation
  * @since 1.0.0
  */
-export const andThenBind: {
+export const bindDiscard: {
   <N extends string, A extends object, B>(
     name: Exclude<N, keyof A>,
     that: ReadonlyArray<B>
@@ -2417,4 +2433,4 @@ export const andThenBind: {
     name: Exclude<N, keyof A>,
     that: ReadonlyArray<B>
   ): Array<{ [K in N | keyof A]: K extends keyof A ? A[K] : B }>
-} = semiProduct.andThenBind(SemiProduct) as any
+} = semiProduct.bindDiscard(SemiProduct) as any

--- a/src/typeclass/Covariant.ts
+++ b/src/typeclass/Covariant.ts
@@ -101,3 +101,29 @@ export {
    */
   let_ as let
 }
+
+/**
+ * @category do notation
+ * @since 1.0.0
+ */
+export const letDiscard = <F extends TypeLambda>(
+  F: Covariant<F>
+): {
+  <N extends string, A extends object, B>(
+    name: Exclude<N, keyof A>,
+    b: B
+  ): <R, O, E>(
+    self: Kind<F, R, O, E, A>
+  ) => Kind<F, R, O, E, { [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+  <R, O, E, A extends object, N extends string, B>(
+    self: Kind<F, R, O, E, A>,
+    name: Exclude<N, keyof A>,
+    b: B
+  ): Kind<F, R, O, E, { [K in keyof A | N]: K extends keyof A ? A[K] : B }>
+} =>
+  dual(3, <R, O, E, A extends object, N extends string, B>(
+    self: Kind<F, R, O, E, A>,
+    name: Exclude<N, keyof A>,
+    b: B
+  ): Kind<F, R, O, E, { [K in keyof A | N]: K extends keyof A ? A[K] : B }> =>
+    F.map(self, (a) => Object.assign({}, a, { [name]: b }) as any))

--- a/src/typeclass/Of.ts
+++ b/src/typeclass/Of.ts
@@ -26,7 +26,7 @@ export const ofComposition = <F extends TypeLambda, G extends TypeLambda>(
  */
 export const unit = <F extends TypeLambda>(
   F: Of<F>
-): Kind<F, unknown, never, never, void> => F.of<void>(undefined)
+): <R = unknown, O = never, E = never>() => Kind<F, R, O, E, void> => () => F.of<void>(undefined)
 
 /**
  * @category do notation
@@ -34,4 +34,4 @@ export const unit = <F extends TypeLambda>(
  */
 export const Do = <F extends TypeLambda>(
   F: Of<F>
-): Kind<F, unknown, never, never, {}> => F.of({})
+): <R = unknown, O = never, E = never>() => Kind<F, R, O, E, {}> => () => F.of({})

--- a/src/typeclass/SemiProduct.ts
+++ b/src/typeclass/SemiProduct.ts
@@ -86,7 +86,7 @@ export const productManyComposition = <F extends TypeLambda, G extends TypeLambd
  * @category do notation
  * @since 1.0.0
  */
-export const andThenBind = <F extends TypeLambda>(F: SemiProduct<F>): {
+export const bindDiscard = <F extends TypeLambda>(F: SemiProduct<F>): {
   <N extends string, A extends object, R2, O2, E2, B>(
     name: Exclude<N, keyof A>,
     that: Kind<F, R2, O2, E2, B>

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -353,7 +353,7 @@ describe.concurrent("Either", () => {
 
   it("andThenBind", () => {
     Util.deepStrictEqual(
-      pipe(E.right(1), E.bindTo("a"), E.andThenBind("b", E.right("b"))),
+      pipe(E.right(1), E.bindTo("a"), E.bindDiscard("b", E.right("b"))),
       E.right({ a: 1, b: "b" })
     )
   })

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -201,7 +201,7 @@ describe.concurrent("Option", () => {
   })
 
   it("unit", () => {
-    Util.deepStrictEqual(_.unit, _.some(undefined))
+    Util.deepStrictEqual(_.unit(), _.some(undefined))
   })
 
   it("product", () => {
@@ -475,7 +475,7 @@ describe.concurrent("Option", () => {
 
   it("andThenBind", () => {
     Util.deepStrictEqual(
-      pipe(_.some(1), _.bindTo("a"), _.andThenBind("b", _.some("b"))),
+      pipe(_.some(1), _.bindTo("a"), _.bindDiscard("b", _.some("b"))),
       _.some({ a: 1, b: "b" })
     )
   })
@@ -521,7 +521,7 @@ describe.concurrent("Option", () => {
   it("guard", () => {
     Util.deepStrictEqual(
       pipe(
-        _.Do,
+        _.Do(),
         _.bind("x", () => _.some("a")),
         _.bind("y", () => _.some("a")),
         _.filter(({ x, y }) => x === y)
@@ -530,7 +530,7 @@ describe.concurrent("Option", () => {
     )
     Util.deepStrictEqual(
       pipe(
-        _.Do,
+        _.Do(),
         _.bind("x", () => _.some("a")),
         _.bind("y", () => _.some("b")),
         _.filter(({ x, y }) => x === y)

--- a/test/Predicate.ts
+++ b/test/Predicate.ts
@@ -27,7 +27,7 @@ describe.concurrent("Predicate", () => {
     expect(_.Do).exist
 
     expect(_.SemiProduct).exist
-    expect(_.andThenBind).exist
+    expect(_.bindDiscard).exist
     expect(_.appendElement).exist
 
     expect(_.Product).exist

--- a/test/ReadonlyArray.ts
+++ b/test/ReadonlyArray.ts
@@ -37,7 +37,7 @@ describe.concurrent("ReadonlyArray", () => {
     expect(RA.Monad).exist
 
     expect(RA.SemiProduct).exist
-    expect(RA.andThenBind).exist
+    expect(RA.bindDiscard).exist
 
     expect(RA.Product).exist
 
@@ -1461,7 +1461,7 @@ describe.concurrent("ReadonlyArray", () => {
   it("do notation", () => {
     deepStrictEqual(
       pipe(
-        RA.Do,
+        RA.Do(),
         RA.bind("a", () => [1, 2, 3]),
         RA.map(({ a }) => a * 2)
       ),
@@ -1470,7 +1470,7 @@ describe.concurrent("ReadonlyArray", () => {
 
     deepStrictEqual(
       pipe(
-        RA.Do,
+        RA.Do(),
         RA.bind("a", () => [1, 2, 3]),
         RA.bind("b", () => ["a", "b"]),
         RA.map(({ a, b }) => [a, b] as const)
@@ -1487,7 +1487,7 @@ describe.concurrent("ReadonlyArray", () => {
 
     deepStrictEqual(
       pipe(
-        RA.Do,
+        RA.Do(),
         RA.bind("a", () => [1, 2, 3]),
         RA.bind("b", () => ["a", "b"]),
         RA.map(({ a, b }) => [a, b] as const),

--- a/test/typeclass/Chainable.ts
+++ b/test/typeclass/Chainable.ts
@@ -14,8 +14,8 @@ describe.concurrent("Chainable", () => {
 
   it("bind", () => {
     const bind = _.bind(O.Chainable)
-    U.deepStrictEqual(pipe(O.Do, bind("a", () => O.none())), O.none())
-    U.deepStrictEqual(pipe(O.Do, bind("a", () => O.some(1))), O.some({ a: 1 }))
+    U.deepStrictEqual(pipe(O.Do(), bind("a", () => O.none())), O.none())
+    U.deepStrictEqual(pipe(O.Do(), bind("a", () => O.some(1))), O.some({ a: 1 }))
   })
 
   it("tap", () => {

--- a/test/typeclass/Of.ts
+++ b/test/typeclass/Of.ts
@@ -10,6 +10,6 @@ describe.concurrent("Of", () => {
   })
 
   it("unit", () => {
-    U.deepStrictEqual(_.unit(O.Pointed), O.some(undefined))
+    U.deepStrictEqual(_.unit(O.Pointed)(), O.some(undefined))
   })
 })

--- a/test/typeclass/SemiProduct.ts
+++ b/test/typeclass/SemiProduct.ts
@@ -125,16 +125,16 @@ describe.concurrent("SemiProduct", () => {
 
   describe.concurrent("andThenBind", () => {
     it("Covariant (Option)", () => {
-      const andThenBind = _.andThenBind(O.Applicative)
+      const andThenBind = _.bindDiscard(O.Applicative)
       U.deepStrictEqual(pipe(O.some({ a: 1 }), andThenBind("b", O.none())), O.none())
       U.deepStrictEqual(pipe(O.some({ a: 1 }), andThenBind("b", O.some(2))), O.some({ a: 1, b: 2 }))
     })
 
     it("Contravariant (Predicate)", () => {
       const p = pipe(
-        P.Do,
-        P.andThenBind("x", String.isString),
-        P.andThenBind("y", Number.isNumber)
+        P.Do(),
+        P.bindDiscard("x", String.isString),
+        P.bindDiscard("y", Number.isNumber)
       )
       U.deepStrictEqual(p({ x: "a", y: 1 }), true)
       U.deepStrictEqual(p({ x: "a", y: "x" }), false)


### PR DESCRIPTION
While it is not strictly needed to make contant constructors lazy given in Effect it is required we should be aligned. This also renames andThenBind to bindDiscard adding a letDiscard variant too