### PR TITLE
refactor: renamed invariant fns

### DIFF
--- a/.changeset/loud-hairs-live.md
+++ b/.changeset/loud-hairs-live.md
@@ -1,0 +1,5 @@
+---
+"@effect/data": minor
+---
+
+renamed tupled, bindTo to asTuple, asProp

--- a/docs/modules/Either.ts.md
+++ b/docs/modules/Either.ts.md
@@ -43,10 +43,10 @@ Added in v1.0.0
   - [appendElement](#appendelement)
   - [bind](#bind)
   - [bindDiscard](#binddiscard)
-  - [bindTo](#bindto)
+  - [asProp](#asprop)
   - [let](#let)
   - [letDiscard](#letdiscard)
-  - [tupled](#tupled)
+  - [asTuple](#astuple)
 - [equivalence](#equivalence)
   - [getEquivalence](#getequivalence)
 - [error handling](#error-handling)
@@ -620,12 +620,12 @@ assert.deepStrictEqual(result, E.left('e1'))
 
 Added in v1.0.0
 
-## bindTo
+## asProp
 
 **Signature**
 
 ```ts
-export declare const bindTo: {
+export declare const asProp: {
   <N extends string>(name: N): <E, A>(self: Either<E, A>) => Either<E, { [K in N]: A }>
   <E, A, N extends string>(self: Either<E, A>, name: N): Either<E, { [K in N]: A }>
 }
@@ -669,12 +669,12 @@ export declare const letDiscard: {
 
 Added in v1.0.0
 
-## tupled
+## asTuple
 
 **Signature**
 
 ```ts
-export declare const tupled: <E, A>(self: Either<E, A>) => Either<E, [A]>
+export declare const asTuple: <E, A>(self: Either<E, A>) => Either<E, [A]>
 ```
 
 Added in v1.0.0

--- a/docs/modules/Identity.ts.md
+++ b/docs/modules/Identity.ts.md
@@ -16,7 +16,7 @@ Added in v1.0.0
   - [Do](#do)
   - [bind](#bind)
   - [bindDiscard](#binddiscard)
-  - [bindTo](#bindto)
+  - [asProp](#asprop)
   - [let](#let)
   - [letDiscard](#letdiscard)
 - [instances](#instances)
@@ -91,12 +91,12 @@ export declare const bindDiscard: {
 
 Added in v1.0.0
 
-## bindTo
+## asProp
 
 **Signature**
 
 ```ts
-export declare const bindTo: {
+export declare const asProp: {
   <N extends string>(name: N): <A>(self: A) => { [K in N]: A }
   <A, N extends string>(self: A, name: N): { [K in N]: A }
 }

--- a/docs/modules/Option.ts.md
+++ b/docs/modules/Option.ts.md
@@ -48,10 +48,10 @@ Added in v1.0.0
   - [appendElement](#appendelement)
   - [bind](#bind)
   - [bindDiscard](#binddiscard)
-  - [bindTo](#bindto)
+  - [asProp](#asprop)
   - [let](#let)
   - [letDiscard](#letdiscard)
-  - [tupled](#tupled)
+  - [asTuple](#astuple)
 - [equivalence](#equivalence)
   - [getEquivalence](#getequivalence)
 - [error handling](#error-handling)
@@ -812,12 +812,12 @@ export declare const bindDiscard: {
 
 Added in v1.0.0
 
-## bindTo
+## asProp
 
 **Signature**
 
 ```ts
-export declare const bindTo: {
+export declare const asProp: {
   <N extends string>(name: N): <A>(self: Option<A>) => Option<{ [K in N]: A }>
   <A, N extends string>(self: Option<A>, name: N): Option<{ [K in N]: A }>
 }
@@ -859,12 +859,12 @@ export declare const letDiscard: {
 
 Added in v1.0.0
 
-## tupled
+## asTuple
 
 **Signature**
 
 ```ts
-export declare const tupled: <A>(self: Option<A>) => Option<[A]>
+export declare const asTuple: <A>(self: Option<A>) => Option<[A]>
 ```
 
 Added in v1.0.0

--- a/docs/modules/Predicate.ts.md
+++ b/docs/modules/Predicate.ts.md
@@ -26,7 +26,7 @@ Added in v1.0.0
 - [do notation](#do-notation)
   - [Do](#do)
   - [bindDiscard](#binddiscard)
-  - [bindTo](#bindto)
+  - [asProp](#asprop)
 - [guards](#guards)
   - [isBigint](#isbigint)
   - [isBoolean](#isboolean)
@@ -72,7 +72,7 @@ Added in v1.0.0
   - [some](#some)
   - [struct](#struct)
   - [tuple](#tuple)
-  - [tupled](#tupled)
+  - [asTuple](#asTuple)
 
 ---
 
@@ -290,12 +290,12 @@ export declare const bindDiscard: {
 
 Added in v1.0.0
 
-## bindTo
+## asProp
 
 **Signature**
 
 ```ts
-export declare const bindTo: {
+export declare const asProp: {
   <N extends string>(name: N): <A>(self: Predicate<A>) => Predicate<{ readonly [K in N]: A }>
   <A, N extends string>(self: Predicate<A>, name: N): Predicate<{ readonly [K in N]: A }>
 }
@@ -989,12 +989,12 @@ export declare const tuple: <T extends readonly Predicate<any>[]>(
 
 Added in v1.0.0
 
-## tupled
+## asTuple
 
 **Signature**
 
 ```ts
-export declare const tupled: <A>(self: Predicate<A>) => Predicate<readonly [A]>
+export declare const asTuple: <A>(self: Predicate<A>) => Predicate<readonly [A]>
 ```
 
 Added in v1.0.0

--- a/docs/modules/ReadonlyArray.ts.md
+++ b/docs/modules/ReadonlyArray.ts.md
@@ -38,7 +38,7 @@ Added in v1.0.0
   - [Do](#do)
   - [bind](#bind)
   - [bindDiscard](#binddiscard)
-  - [bindTo](#bindto)
+  - [asProp](#asprop)
   - [let](#let)
   - [letDiscard](#letdiscard)
 - [filtering](#filtering)
@@ -131,7 +131,7 @@ Added in v1.0.0
   - [map](#map)
   - [mapNonEmpty](#mapnonempty)
   - [tuple](#tuple)
-  - [tupled](#tupled)
+  - [asTuple](#astuple)
 - [models](#models)
   - [NonEmptyArray (type alias)](#nonemptyarray-type-alias)
   - [NonEmptyReadonlyArray (type alias)](#nonemptyreadonlyarray-type-alias)
@@ -502,12 +502,12 @@ export declare const bindDiscard: {
 
 Added in v1.0.0
 
-## bindTo
+## asProp
 
 **Signature**
 
 ```ts
-export declare const bindTo: {
+export declare const asProp: {
   <N extends string>(name: N): <A>(self: readonly A[]) => { [K in N]: A }[]
   <A, N extends string>(self: readonly A[], name: N): { [K in N]: A }[]
 }
@@ -1649,12 +1649,12 @@ export declare const tuple: <Args extends any[]>(...args: Args) => Args
 
 Added in v1.0.0
 
-## tupled
+## asTuple
 
 **Signature**
 
 ```ts
-export declare const tupled: <A>(self: readonly A[]) => [A][]
+export declare const asTuple: <A>(self: readonly A[]) => [A][]
 ```
 
 Added in v1.0.0

--- a/docs/modules/typeclass/Invariant.ts.md
+++ b/docs/modules/typeclass/Invariant.ts.md
@@ -18,23 +18,23 @@ Added in v1.0.0
 <h2 class="text-delta">Table of contents</h2>
 
 - [do notation](#do-notation)
-  - [bindTo](#bindto)
+  - [asProp](#asprop)
 - [type class](#type-class)
   - [Invariant (interface)](#invariant-interface)
 - [utils](#utils)
   - [imapComposition](#imapcomposition)
-  - [tupled](#tupled)
+  - [asTuple](#astuple)
 
 ---
 
 # do notation
 
-## bindTo
+## asProp
 
 **Signature**
 
 ```ts
-export declare const bindTo: <F extends TypeLambda>(
+export declare const asProp: <F extends TypeLambda>(
   F: Invariant<F>
 ) => {
   <N extends string>(name: N): <R, O, E, A>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, { [K in N]: A }>
@@ -82,14 +82,14 @@ export declare const imapComposition: <F extends TypeLambda, G extends TypeLambd
 
 Added in v1.0.0
 
-## tupled
+## asTuple
 
 Convert a value in a singleton array in a given effect.
 
 **Signature**
 
 ```ts
-export declare const tupled: <F extends TypeLambda>(
+export declare const asTuple: <F extends TypeLambda>(
   F: Invariant<F>
 ) => <R, O, E, A>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, [A]>
 ```

--- a/guides/typeclass.md
+++ b/guides/typeclass.md
@@ -310,8 +310,8 @@ Invariant functors.
 | --------------- | ----------------------------- | ------------------ |
 | **imap**        | `F<A>`, `A => B`, `B => A`    | `F<B>`             |
 | imapComposition | `F<G<A>>`, `A => B`, `B => A` | `F<G<B>>`          |
-| bindTo          | `F<A>`, `name: string`        | `F<{ [name]: A }>` |
-| tupled          | `F<A>`                        | `F<[A]>`           |
+| asProp          | `F<A>`, `name: string`        | `F<{ [name]: A }>` |
+| asTuple         | `F<A>`                        | `F<[A]>`           |
 
 ### Monad
 

--- a/src/Either.ts
+++ b/src/Either.ts
@@ -1443,7 +1443,7 @@ export const lefts = <E, A>(self: Iterable<Either<E, A>>): Array<E> => {
  * @category do notation
  * @since 1.0.0
  */
-export const tupled: <E, A>(self: Either<E, A>) => Either<E, [A]> = invariant.tupled(
+export const asTuple: <E, A>(self: Either<E, A>) => Either<E, [A]> = invariant.asTuple(
   Invariant
 )
 
@@ -1467,12 +1467,12 @@ export const appendElement: {
  * @category do notation
  * @since 1.0.0
  */
-export const bindTo: {
+export const asProp: {
   <N extends string>(
     name: N
   ): <E, A>(self: Either<E, A>) => Either<E, { [K in N]: A }>
   <E, A, N extends string>(self: Either<E, A>, name: N): Either<E, { [K in N]: A }>
-} = invariant.bindTo(Invariant)
+} = invariant.asProp(Invariant)
 
 const let_: {
   <N extends string, A extends object, B>(

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -232,10 +232,10 @@ export const Traversable: traversable.Traversable<IdentityTypeLambda> = {
  * @category do notation
  * @since 1.0.0
  */
-export const bindTo: {
+export const asProp: {
   <N extends string>(name: N): <A>(self: Identity<A>) => Identity<{ [K in N]: A }>
   <A, N extends string>(self: Identity<A>, name: N): Identity<{ [K in N]: A }>
-} = invariant.bindTo(Invariant)
+} = invariant.asProp(Invariant)
 
 const let_: {
   <N extends string, A extends object, B>(

--- a/src/Option.ts
+++ b/src/Option.ts
@@ -1683,7 +1683,7 @@ export const multiplyCompact = (self: Iterable<Option<number>>): number => {
  * @category do notation
  * @since 1.0.0
  */
-export const tupled: <A>(self: Option<A>) => Option<[A]> = invariant.tupled(Invariant)
+export const asTuple: <A>(self: Option<A>) => Option<[A]> = invariant.asTuple(Invariant)
 
 /**
  * Appends an element to the end of a tuple wrapped in an `Option` type.
@@ -1709,10 +1709,10 @@ export const appendElement: {
  * @category do notation
  * @since 1.0.0
  */
-export const bindTo: {
+export const asProp: {
   <N extends string>(name: N): <A>(self: Option<A>) => Option<{ [K in N]: A }>
   <A, N extends string>(self: Option<A>, name: N): Option<{ [K in N]: A }>
-} = invariant.bindTo(Invariant)
+} = invariant.asProp(Invariant)
 
 const let_: {
   <N extends string, A extends object, B>(

--- a/src/Predicate.ts
+++ b/src/Predicate.ts
@@ -444,7 +444,7 @@ export const Invariant: invariant.Invariant<PredicateTypeLambda> = {
 /**
  * @since 1.0.0
  */
-export const tupled: <A>(self: Predicate<A>) => Predicate<readonly [A]> = invariant.tupled(
+export const asTuple: <A>(self: Predicate<A>) => Predicate<readonly [A]> = invariant.asTuple(
   Invariant
 ) as any
 
@@ -766,10 +766,10 @@ export const some = <A>(collection: Iterable<Predicate<A>>): Predicate<A> => get
  * @category do notation
  * @since 1.0.0
  */
-export const bindTo: {
+export const asProp: {
   <N extends string>(name: N): <A>(self: Predicate<A>) => Predicate<{ readonly [K in N]: A }>
   <A, N extends string>(self: Predicate<A>, name: N): Predicate<{ readonly [K in N]: A }>
-} = invariant.bindTo(Invariant)
+} = invariant.asProp(Invariant)
 
 /**
  * @category do notation

--- a/src/ReadonlyArray.ts
+++ b/src/ReadonlyArray.ts
@@ -1497,8 +1497,8 @@ export const Invariant: invariant.Invariant<ReadonlyArrayTypeLambda> = {
  * @category mapping
  * @since 1.0.0
  */
-export const tupled: <A>(self: ReadonlyArray<A>) => Array<[A]> = invariant
-  .tupled(Invariant) as any
+export const asTuple: <A>(self: ReadonlyArray<A>) => Array<[A]> = invariant
+  .asTuple(Invariant) as any
 
 /**
  * @category mapping
@@ -2360,10 +2360,10 @@ export const getEquivalence: <A>(O: Equivalence<A>) => Equivalence<ReadonlyArray
  * @category do notation
  * @since 1.0.0
  */
-export const bindTo: {
+export const asProp: {
   <N extends string>(name: N): <A>(self: ReadonlyArray<A>) => Array<{ [K in N]: A }>
   <A, N extends string>(self: ReadonlyArray<A>, name: N): Array<{ [K in N]: A }>
-} = invariant.bindTo(Invariant) as any
+} = invariant.asProp(Invariant) as any
 
 const let_: {
   <N extends string, A extends object, B>(

--- a/src/ReadonlyRecord.ts
+++ b/src/ReadonlyRecord.ts
@@ -736,7 +736,7 @@ export const Invariant: invariant.Invariant<ReadonlyRecordTypeLambda> = {
  * @category mapping
  * @since 1.0.0
  */
-export const tupled: <A>(self: ReadonlyRecord<A>) => Record<string, [A]> = invariant.tupled(
+export const asTuple: <A>(self: ReadonlyRecord<A>) => Record<string, [A]> = invariant.asTuple(
   Invariant
 )
 

--- a/src/typeclass/Invariant.ts
+++ b/src/typeclass/Invariant.ts
@@ -46,7 +46,7 @@ export const imapComposition = <F extends TypeLambda, G extends TypeLambda>(
  * @category do notation
  * @since 1.0.0
  */
-export const bindTo = <F extends TypeLambda>(F: Invariant<F>): {
+export const asProp = <F extends TypeLambda>(F: Invariant<F>): {
   <N extends string>(
     name: N
   ): <R, O, E, A>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, { [K in N]: A }>
@@ -65,6 +65,6 @@ export const bindTo = <F extends TypeLambda>(F: Invariant<F>): {
  *
  * @since 1.0.0
  */
-export const tupled = <F extends TypeLambda>(
+export const asTuple = <F extends TypeLambda>(
   F: Invariant<F>
 ): (<R, O, E, A>(self: Kind<F, R, O, E, A>) => Kind<F, R, O, E, [A]>) => F.imap((a) => [a], ([a]) => a)

--- a/test/Either.ts
+++ b/test/Either.ts
@@ -15,8 +15,8 @@ describe.concurrent("Either", () => {
     expect(E.getLeft).exist
 
     expect(E.Invariant).exist
-    expect(E.tupled).exist
-    expect(E.bindTo).exist
+    expect(E.asTuple).exist
+    expect(E.asProp).exist
 
     expect(E.Covariant).exist
     expect(E.map).exist
@@ -365,7 +365,7 @@ describe.concurrent("Either", () => {
     Util.deepStrictEqual(
       pipe(
         E.right(1),
-        E.bindTo("a"),
+        E.asProp("a"),
         E.bind("b", () => E.right("b")),
         E.let("c", ({ a, b }) => [a, b])
       ),
@@ -375,7 +375,7 @@ describe.concurrent("Either", () => {
 
   it("andThenBind", () => {
     Util.deepStrictEqual(
-      pipe(E.right(1), E.bindTo("a"), E.bindDiscard("b", E.right("b"))),
+      pipe(E.right(1), E.asProp("a"), E.bindDiscard("b", E.right("b"))),
       E.right({ a: 1, b: "b" })
     )
   })
@@ -441,7 +441,7 @@ describe.concurrent("Either", () => {
   })
 
   it("element", () => {
-    expect(pipe(E.right(1), E.tupled, E.appendElement(E.right("b")))).toEqual(
+    expect(pipe(E.right(1), E.asTuple, E.appendElement(E.right("b")))).toEqual(
       E.right([1, "b"])
     )
   })

--- a/test/Identity.ts
+++ b/test/Identity.ts
@@ -20,7 +20,7 @@ describe.concurrent("Identity", () => {
     expect(_.Foldable).exist
     expect(_.Traversable).exist
 
-    expect(_.bindTo).exist
+    expect(_.asProp).exist
     expect(_.let).exist
     expect(_.Do).exist
     expect(_.bind).exist

--- a/test/Option.ts
+++ b/test/Option.ts
@@ -19,8 +19,8 @@ describe.concurrent("Option", () => {
     expect(_.getLeft).exist
 
     expect(_.Invariant).exist
-    expect(_.tupled).exist
-    expect(_.bindTo).exist
+    expect(_.asTuple).exist
+    expect(_.asProp).exist
 
     expect(_.Covariant).exist
     expect(_.map).exist
@@ -488,7 +488,7 @@ describe.concurrent("Option", () => {
     Util.deepStrictEqual(
       pipe(
         _.some(1),
-        _.bindTo("a"),
+        _.asProp("a"),
         _.bind("b", () => _.some("b"))
       ),
       _.some({ a: 1, b: "b" })
@@ -497,13 +497,13 @@ describe.concurrent("Option", () => {
 
   it("andThenBind", () => {
     Util.deepStrictEqual(
-      pipe(_.some(1), _.bindTo("a"), _.bindDiscard("b", _.some("b"))),
+      pipe(_.some(1), _.asProp("a"), _.bindDiscard("b", _.some("b"))),
       _.some({ a: 1, b: "b" })
     )
   })
 
   it("element", () => {
-    expect(pipe(_.some(1), _.tupled, _.appendElement(_.some("b")))).toEqual(
+    expect(pipe(_.some(1), _.asTuple, _.appendElement(_.some("b")))).toEqual(
       _.some([1, "b"])
     )
   })

--- a/test/Predicate.ts
+++ b/test/Predicate.ts
@@ -18,8 +18,8 @@ const NonEmptyString: _.Refinement<string, NonEmptyString> = (s): s is NonEmptyS
 describe.concurrent("Predicate", () => {
   it("instances and derived exports", () => {
     expect(_.Invariant).exist
-    expect(_.tupled).exist
-    expect(_.bindTo).exist
+    expect(_.asTuple).exist
+    expect(_.asProp).exist
 
     expect(_.Contravariant).exist
     expect(_.contramap).exist

--- a/test/ReadonlyArray.ts
+++ b/test/ReadonlyArray.ts
@@ -13,8 +13,8 @@ import * as fc from "fast-check"
 describe.concurrent("ReadonlyArray", () => {
   it("exports", () => {
     expect(RA.Invariant).exist
-    expect(RA.tupled).exist
-    expect(RA.bindTo).exist
+    expect(RA.asTuple).exist
+    expect(RA.asProp).exist
 
     expect(RA.Covariant).exist
     expect(RA.map).exist

--- a/test/ReadonlyRecord.ts
+++ b/test/ReadonlyRecord.ts
@@ -6,7 +6,7 @@ import * as RR from "@effect/data/ReadonlyRecord"
 describe.concurrent("ReadonlyRecord", () => {
   it("exports", () => {
     expect(RR.Invariant).exist
-    expect(RR.tupled).exist
+    expect(RR.asTuple).exist
     expect(RR.Covariant).exist
     expect(RR.flap).exist
     expect(RR.as).exist

--- a/test/typeclass/Invariant.ts
+++ b/test/typeclass/Invariant.ts
@@ -19,31 +19,31 @@ describe.concurrent("Invariant", () => {
     )
   })
 
-  describe.concurrent("bindTo", () => {
+  describe.concurrent("asProp", () => {
     it("Covariant (Option)", () => {
-      const bindTo = _.bindTo(O.Invariant)
-      U.deepStrictEqual(pipe(O.none(), bindTo("a")), O.none())
-      U.deepStrictEqual(pipe(O.some(1), bindTo("a")), O.some({ a: 1 }))
+      const asProp = _.asProp(O.Invariant)
+      U.deepStrictEqual(pipe(O.none(), asProp("a")), O.none())
+      U.deepStrictEqual(pipe(O.some(1), asProp("a")), O.some({ a: 1 }))
     })
 
     it("Contravariant (Predicate)", () => {
-      const bindTo = _.bindTo(P.Invariant)
-      const p = pipe(String.isString, bindTo("a"))
+      const asProp = _.asProp(P.Invariant)
+      const p = pipe(String.isString, asProp("a"))
       U.deepStrictEqual(p({ a: "a" }), true)
       U.deepStrictEqual(p({ a: 1 }), false)
     })
   })
 
-  describe.concurrent("tupled", () => {
+  describe.concurrent("asTuple", () => {
     it("Covariant (Option)", () => {
-      const tupled = _.tupled(O.Invariant)
-      U.deepStrictEqual(pipe(O.none(), tupled), O.none())
-      U.deepStrictEqual(pipe(O.some(1), tupled), O.some([1]))
+      const asTuple = _.asTuple(O.Invariant)
+      U.deepStrictEqual(pipe(O.none(), asTuple), O.none())
+      U.deepStrictEqual(pipe(O.some(1), asTuple), O.some([1]))
     })
 
     it("Contravariant (Predicate)", () => {
-      const tupled = _.tupled(P.Invariant)
-      const p = pipe(String.isString, tupled)
+      const asTuple = _.asTuple(P.Invariant)
+      const p = pipe(String.isString, asTuple)
       U.deepStrictEqual(p(["a"]), true)
       U.deepStrictEqual(p([1]), false)
     })


### PR DESCRIPTION
A subset of the discussion on the Do api. Renames bindTo to asProp and tupled to asTuple. 