### PR TITLE
Patch RedBlackTree find method.

### DIFF
--- a/.changeset/giant-hornets-fail.md
+++ b/.changeset/giant-hornets-fail.md
@@ -1,0 +1,5 @@
+---
+"@effect/data": patch
+---
+
+Patches RedBlackTree find method to correctly return all results for a key

--- a/src/internal/RedBlackTree.ts
+++ b/src/internal/RedBlackTree.ts
@@ -153,16 +153,19 @@ export const find = Dual.dual<
   const cmp = (self as RedBlackTreeImpl<K, V>)._ord.compare
   let node = (self as RedBlackTreeImpl<K, V>)._root
   let result = Chunk.empty<V>()
-  while (node !== undefined) {
-    const d = cmp(key, node.key)
-    if (d === 0 && Equal.equals(key, node.key)) {
-      result = Chunk.prepend(node.value)(result)
-    }
-    if (d <= 0) {
-      node = node.left
+  let stack: Array<Node.Node<K, V>> = []
+  while (node !== undefined || stack.length > 0) {
+    if (node) {
+      stack.push(node);
+      node = node.left;
     } else {
-      node = node.right
+      const current = stack.pop();
+      if (cmp(current.key, key) === 0) {
+        result = Chunk.prepend(current.value)(result)
+      }
+      node = current.right;
     }
+
   }
   return result
 })

--- a/src/internal/RedBlackTree.ts
+++ b/src/internal/RedBlackTree.ts
@@ -150,22 +150,20 @@ export const find = Dual.dual<
   <K>(key: K) => <V>(self: RBT.RedBlackTree<K, V>) => Chunk.Chunk<V>,
   <K, V>(self: RBT.RedBlackTree<K, V>, key: K) => Chunk.Chunk<V>
 >(2, <K, V>(self: RBT.RedBlackTree<K, V>, key: K) => {
-  const cmp = (self as RedBlackTreeImpl<K, V>)._ord.compare
+  const stack: Array<Node.Node<K, V>> = []
   let node = (self as RedBlackTreeImpl<K, V>)._root
   let result = Chunk.empty<V>()
-  let stack: Array<Node.Node<K, V>> = []
   while (node !== undefined || stack.length > 0) {
     if (node) {
-      stack.push(node);
-      node = node.left;
+      stack.push(node)
+      node = node.left
     } else {
-      const current = stack.pop();
-      if (cmp(current.key, key) === 0) {
+      const current = stack.pop()!
+      if (Equal.equals(key, current.key)) {
         result = Chunk.prepend(current.value)(result)
       }
-      node = current.right;
+      node = current.right
     }
-
   }
   return result
 })

--- a/test/RedBlackTree.ts
+++ b/test/RedBlackTree.ts
@@ -322,10 +322,22 @@ describe.concurrent("RedBlackTree", () => {
       RedBlackTree.insert(1, "e")
     )
 
-    deepStrictEqual(Array.from(RedBlackTree.find(1)(tree)), ["e", "b", "a"])
+    deepStrictEqual(Array.from(RedBlackTree.find(1)(tree)), ["a", "b", "e"])
+
+    const bigintTree = pipe(
+      RedBlackTree.empty(Order.bigint),
+      RedBlackTree.insert(1n, 1),
+      RedBlackTree.insert(1n, 2),
+      RedBlackTree.insert(1n, 3),
+      RedBlackTree.insert(1n, 4),
+      RedBlackTree.insert(1n, 5),
+      RedBlackTree.insert(2n, 6)
+    )
+
+    deepStrictEqual(Array.from(RedBlackTree.find(1n)(bigintTree)), [1, 2, 3, 4, 5])
   })
 
-  it("find Eq/Ord", () => {
+  it.only("find Eq/Ord", () => {
     class Key {
       constructor(readonly n: number, readonly s: string) {}
 
@@ -352,7 +364,7 @@ describe.concurrent("RedBlackTree", () => {
     )
 
     deepStrictEqual(Array.from(RedBlackTree.values(tree)), ["g", "f", "e", "b", "a", "c", "d"])
-    deepStrictEqual(Array.from(RedBlackTree.find(new Key(1, "0"))(tree)), ["f", "e", "a"])
+    deepStrictEqual(Array.from(RedBlackTree.find(new Key(1, "0"))(tree)), ["a", "e", "f"])
     deepStrictEqual(
       Array.from(RedBlackTree.values(RedBlackTree.removeFirst(new Key(1, "1"))(tree))),
       [

--- a/test/RedBlackTree.ts
+++ b/test/RedBlackTree.ts
@@ -337,7 +337,7 @@ describe.concurrent("RedBlackTree", () => {
     deepStrictEqual(Array.from(RedBlackTree.find(1n)(bigintTree)), [1, 2, 3, 4, 5])
   })
 
-  it.only("find Eq/Ord", () => {
+  it("find Eq/Ord", () => {
     class Key {
       constructor(readonly n: number, readonly s: string) {}
 


### PR DESCRIPTION
Previous bug:
```ts
const tree = pipe(
  RedBlackTree.empty(Order.bigint),
  RedBlackTree.insert(1n, 1),
  RedBlackTree.insert(1n, 2),
  RedBlackTree.insert(1n, 3),
  RedBlackTree.insert(1n, 4),
  RedBlackTree.insert(1n, 5)
);

// When I try to find all values against the key `1n`
console.log(pipe(tree, RedBlackTree.find(1n))); 
// Prints only a subset
// { _tag: 'Chunk', values: [ 5, 4, 2 ] }

// However
console.log(
  pipe(
    tree,
    RedBlackTree.forEachGreaterThanEqual(1n, (k, v) => console.log(k, v))
  )
); 
// Prints 
// 1n 5
// 1n 4
// 1n 3
// 1n 2
// 1n 1
```

Now correctly returns `[ 5, 4, 3, 2, 1 ]`

Proof of previous failures when adding test case to `main` branch:
<img width="573" alt="Screenshot 2023-05-24 at 5 00 12 pm" src="https://github.com/Effect-TS/data/assets/106667397/154ddf82-6d9d-4b0a-ba68-426c0cbca665">

Now new test case and all existing are passing.