### PR TITLE
feat: add missing functions in String

### DIFF
--- a/.changeset/chilly-eagles-count.md
+++ b/.changeset/chilly-eagles-count.md
@@ -1,5 +1,5 @@
 ---
-"@effect/data": minor
+'@effect/data': patch
 ---
 
 Add missing functions in String

--- a/.changeset/chilly-eagles-count.md
+++ b/.changeset/chilly-eagles-count.md
@@ -1,0 +1,5 @@
+---
+"@effect/data": minor
+---
+
+Add missing functions in String

--- a/docs/modules/String.ts.md
+++ b/docs/modules/String.ts.md
@@ -147,18 +147,17 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const at: {
-  (index: number): (self: string) => string | undefined
-  (self: string, index: number): string | undefined
-}
+export declare const at: (index: number) => (self: string) => string | undefined
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.at('abc', 1), 'b')
+assert.deepStrictEqual(pipe('abc', S.at(1)), 'b')
+assert.deepStrictEqual(pipe('abc', S.at(4)), undefined)
 ```
 
 Added in v1.0.0
@@ -168,15 +167,16 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const charAt: { (index: number): (self: string) => string; (self: string, index: number): string }
+export declare const charAt: (index: number) => (self: string) => string
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.charAt('abc', 1), 'b')
+assert.deepStrictEqual(pipe('abc', S.charAt(1)), 'b')
 ```
 
 Added in v1.0.0
@@ -186,15 +186,16 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const charCodeAt: { (index: number): (self: string) => number; (self: string, index: number): number }
+export declare const charCodeAt: (index: number) => (self: string) => number
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.charCodeAt('abc', 1), 98)
+assert.deepStrictEqual(pipe('abc', S.charCodeAt(1)), 98)
 ```
 
 Added in v1.0.0
@@ -204,18 +205,16 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const codePointAt: {
-  (index: number): (self: string) => number | undefined
-  (self: string, index: number): number | undefined
-}
+export declare const codePointAt: (index: number) => (self: string) => number | undefined
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.codePointAt('abc', 1), 98)
+assert.deepStrictEqual(pipe('abc', S.codePointAt(1)), 98)
 ```
 
 Added in v1.0.0
@@ -341,18 +340,16 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const indexOf: {
-  (searchString: string): (self: string) => number
-  (self: string, searchString: string): number
-}
+export declare const indexOf: (searchString: string) => (self: string) => number
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.indexOf('abbbc', 'b'), 1)
+assert.deepStrictEqual(pipe('abbbc', S.indexOf('b')), 1)
 ```
 
 Added in v1.0.0
@@ -395,18 +392,16 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const lastIndexOf: {
-  (searchString: string): (self: string) => number
-  (self: string, searchString: string): number
-}
+export declare const lastIndexOf: (searchString: string) => (self: string) => number
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.lastIndexOf('abbbc', 'b'), 3)
+assert.deepStrictEqual(pipe('abbbc', S.lastIndexOf('b')), 3)
 ```
 
 Added in v1.0.0
@@ -449,62 +444,46 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const localeCompare: {
-  (compareString: string): (self: string) => number
-  (self: string, compareString: string): number
-}
+export declare const localeCompare: (
+  that: string,
+  locales?: Array<string>,
+  options?: Intl.CollatorOptions
+) => (self: string) => number
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.localeCompare('a', 'b'), -1)
-assert.deepStrictEqual(S.localeCompare('b', 'a'), 1)
-assert.deepStrictEqual(S.localeCompare('a', 'a'), 0)
+assert.deepStrictEqual(pipe('a', S.localeCompare('b')), -1)
+assert.deepStrictEqual(pipe('b', S.localeCompare('a')), 1)
+assert.deepStrictEqual(pipe('a', S.localeCompare('a')), 0)
 ```
 
 Added in v1.0.0
 
 ## match
 
+It is the `pipe`-able version of the native `match` method.
+
 **Signature**
 
 ```ts
-export declare const match: {
-  (regexp: RegExp | string): (self: string) => RegExpMatchArray | null
-  (self: string, regexp: RegExp | string): RegExpMatchArray | null
-}
-```
-
-**Example**
-
-```ts
-import * as S from '@effect/data/String'
-
-assert.ok(S.match('a', /a/)?.[0] === 'a')
+export declare const match: (regexp: RegExp | string) => (self: string) => RegExpMatchArray | null
 ```
 
 Added in v1.0.0
 
 ## matchAll
 
+It is the `pipe`-able version of the native `matchAll` method.
+
 **Signature**
 
 ```ts
-export declare const matchAll: {
-  (regexp: RegExp): (self: string) => IterableIterator<RegExpMatchArray>
-  (self: string, regexp: RegExp): IterableIterator<RegExpMatchArray>
-}
-```
-
-**Example**
-
-```ts
-import * as S from '@effect/data/String'
-
-assert.ok([...S.matchAll('ababb', /a/g)].length === 2)
+export declare const matchAll: (regexp: RegExp) => (self: string) => IterableIterator<RegExpMatchArray>
 ```
 
 Added in v1.0.0
@@ -514,18 +493,21 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const normalize: {
-  (form: 'NFC' | 'NFD' | 'NFKC' | 'NFKD'): (self: string) => string
-  (self: string, form: 'NFC' | 'NFD' | 'NFKC' | 'NFKD'): string
-}
+export declare const normalize: (form?: 'NFC' | 'NFD' | 'NFKC' | 'NFKD') => (self: string) => string
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.normalize('a', 'NFC'), 'a')
+const str = '\u1E9B\u0323'
+assert.deepStrictEqual(pipe(str, S.normalize()), '\u1E9B\u0323')
+assert.deepStrictEqual(pipe(str, S.normalize('NFC')), '\u1E9B\u0323')
+assert.deepStrictEqual(pipe(str, S.normalize('NFD')), '\u017F\u0323\u0307')
+assert.deepStrictEqual(pipe(str, S.normalize('NFKC')), '\u1E69')
+assert.deepStrictEqual(pipe(str, S.normalize('NFKD')), '\u0073\u0323\u0307')
 ```
 
 Added in v1.0.0
@@ -535,18 +517,17 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const padEnd: {
-  (maxLength: number, fillString?: string): (self: string) => string
-  (self: string, maxLength: number, fillString?: string): string
-}
+export declare const padEnd: (maxLength: number, fillString?: string) => (self: string) => string
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.padEnd('a', 5), 'a    ')
+assert.deepStrictEqual(pipe('a', S.padEnd(5)), 'a    ')
+assert.deepStrictEqual(pipe('a', S.padEnd(5, '_')), 'a____')
 ```
 
 Added in v1.0.0
@@ -556,18 +537,17 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const padStart: {
-  (maxLength: number, fillString?: string): (self: string) => string
-  (self: string, maxLength: number, fillString?: string): string
-}
+export declare const padStart: (maxLength: number, fillString?: string) => (self: string) => string
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.padStart('a', 5), '    a')
+assert.deepStrictEqual(pipe('a', S.padStart(5)), '    a')
+assert.deepStrictEqual(pipe('a', S.padStart(5, '_')), '____a')
 ```
 
 Added in v1.0.0
@@ -577,15 +557,16 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const repeat: { (count: number): (self: string) => string; (self: string, count: number): string }
+export declare const repeat: (count: number) => (self: string) => string
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.repeat('a', 3), 'aaa')
+assert.deepStrictEqual(pipe('a', S.repeat(5)), 'aaaaa')
 ```
 
 Added in v1.0.0
@@ -617,18 +598,17 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const replaceAll: {
-  (searchValue: string | RegExp, replaceValue: string): (self: string) => string
-  (self: string, searchValue: string | RegExp, replaceValue: string): string
-}
+export declare const replaceAll: (searchValue: string | RegExp, replaceValue: string) => (self: string) => string
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.replaceAll('ababb', 'b', 'c'), 'acacc')
+assert.deepStrictEqual(pipe('ababb', S.replaceAll('b', 'c')), 'acacc')
+assert.deepStrictEqual(pipe('ababb', S.replaceAll(/ba/g, 'cc')), 'accbb')
 ```
 
 Added in v1.0.0
@@ -638,18 +618,17 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const search: {
-  (regexp: RegExp | string): (self: string) => number
-  (self: string, regexp: RegExp | string): number
-}
+export declare const search: (regexp: RegExp | string) => (self: string) => number
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.search('ababb', 'b'), 1)
+assert.deepStrictEqual(pipe('ababb', S.search('b')), 1)
+assert.deepStrictEqual(pipe('ababb', S.search(/abb/)), 2)
 ```
 
 Added in v1.0.0
@@ -780,15 +759,17 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const substring: { (start: number): (self: string) => string; (self: string, start: number): string }
+export declare const substring: (start: number, end?: number) => (self: string) => string
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.substring('abcd', 1), 'bcd')
+assert.deepStrictEqual(pipe('abcd', S.substring(1)), 'bcd')
+assert.deepStrictEqual(pipe('abcd', S.substring(1, 3)), 'bc')
 ```
 
 Added in v1.0.0
@@ -852,18 +833,17 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const toLocaleLowerCase: {
-  (locale?: string | Array<string>): (self: string) => string
-  (self: string, locale?: string | Array<string>): string
-}
+export declare const toLocaleLowerCase: (locale?: string | Array<string>) => (self: string) => string
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.toLocaleLowerCase('\u0130', 'tr'), 'i')
+const str = '\u0130'
+assert.deepStrictEqual(pipe(str, S.toLocaleLowerCase('tr')), 'i')
 ```
 
 Added in v1.0.0
@@ -873,18 +853,17 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const toLocaleUpperCase: {
-  (locale?: string | Array<string>): (self: string) => string
-  (self: string, locale?: string | Array<string>): string
-}
+export declare const toLocaleUpperCase: (locale?: string | Array<string>) => (self: string) => string
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(S.toLocaleUpperCase('i\u0307', 'lt-LT'), 'I')
+const str = 'i\u0307'
+assert.deepStrictEqual(pipe(str, S.toLocaleUpperCase('lt-LT')), 'I')
 ```
 
 Added in v1.0.0

--- a/docs/modules/String.ts.md
+++ b/docs/modules/String.ts.md
@@ -147,17 +147,18 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const at: (index: number) => (self: string) => string | undefined
+export declare const at: (index: number) => (self: string) => Option.Option<string>
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import * as Option from '@effect/data/Option'
 import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(pipe('abc', S.at(1)), 'b')
-assert.deepStrictEqual(pipe('abc', S.at(4)), undefined)
+assert.deepStrictEqual(pipe('abc', S.at(1)), Option.some('b'))
+assert.deepStrictEqual(pipe('abc', S.at(4)), Option.none())
 ```
 
 Added in v1.0.0
@@ -167,16 +168,18 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const charAt: (index: number) => (self: string) => string
+export declare const charAt: (index: number) => (self: string) => Option.Option<string>
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import * as Option from '@effect/data/Option'
 import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(pipe('abc', S.charAt(1)), 'b')
+assert.deepStrictEqual(pipe('abc', S.charAt(1)), Option.some('b'))
+assert.deepStrictEqual(pipe('abc', S.charAt(4)), Option.none())
 ```
 
 Added in v1.0.0
@@ -186,16 +189,18 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const charCodeAt: (index: number) => (self: string) => number
+export declare const charCodeAt: (index: number) => (self: string) => Option.Option<number>
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import * as Option from '@effect/data/Option'
 import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(pipe('abc', S.charCodeAt(1)), 98)
+assert.deepStrictEqual(pipe('abc', S.charCodeAt(1)), Option.some(98))
+assert.deepStrictEqual(pipe('abc', S.charCodeAt(4)), Option.none())
 ```
 
 Added in v1.0.0
@@ -205,16 +210,17 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const codePointAt: (index: number) => (self: string) => number | undefined
+export declare const codePointAt: (index: number) => (self: string) => Option.Option<number>
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import * as Option from '@effect/data/Option'
 import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(pipe('abc', S.codePointAt(1)), 98)
+assert.deepStrictEqual(pipe('abc', S.codePointAt(1)), Option.some(98))
 ```
 
 Added in v1.0.0
@@ -340,16 +346,17 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const indexOf: (searchString: string) => (self: string) => number
+export declare const indexOf: (searchString: string) => (self: string) => Option.Option<number>
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import * as Option from '@effect/data/Option'
 import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(pipe('abbbc', S.indexOf('b')), 1)
+assert.deepStrictEqual(pipe('abbbc', S.indexOf('b')), Option.some(1))
 ```
 
 Added in v1.0.0
@@ -392,16 +399,18 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const lastIndexOf: (searchString: string) => (self: string) => number
+export declare const lastIndexOf: (searchString: string) => (self: string) => Option.Option<number>
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import * as Option from '@effect/data/Option'
 import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(pipe('abbbc', S.lastIndexOf('b')), 3)
+assert.deepStrictEqual(pipe('abbbc', S.lastIndexOf('b')), Option.some(3))
+assert.deepStrictEqual(pipe('abbbc', S.lastIndexOf('d')), Option.none())
 ```
 
 Added in v1.0.0
@@ -448,7 +457,7 @@ export declare const localeCompare: (
   that: string,
   locales?: Array<string>,
   options?: Intl.CollatorOptions
-) => (self: string) => number
+) => (self: string) => Ordering.Ordering
 ```
 
 **Example**
@@ -471,7 +480,7 @@ It is the `pipe`-able version of the native `match` method.
 **Signature**
 
 ```ts
-export declare const match: (regexp: RegExp | string) => (self: string) => RegExpMatchArray | null
+export declare const match: (regexp: RegExp | string) => (self: string) => Option.Option<RegExpMatchArray>
 ```
 
 Added in v1.0.0
@@ -618,17 +627,19 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const search: (regexp: RegExp | string) => (self: string) => number
+export declare const search: (regexp: RegExp | string) => (self: string) => Option.Option<number>
 ```
 
 **Example**
 
 ```ts
 import * as S from '@effect/data/String'
+import * as Option from '@effect/data/Option'
 import { pipe } from '@effect/data/Function'
 
-assert.deepStrictEqual(pipe('ababb', S.search('b')), 1)
-assert.deepStrictEqual(pipe('ababb', S.search(/abb/)), 2)
+assert.deepStrictEqual(pipe('ababb', S.search('b')), Option.some(1))
+assert.deepStrictEqual(pipe('ababb', S.search(/abb/)), Option.some(2))
+assert.deepStrictEqual(pipe('ababb', S.search('d')), Option.none())
 ```
 
 Added in v1.0.0

--- a/docs/modules/String.ts.md
+++ b/docs/modules/String.ts.md
@@ -24,25 +24,43 @@ Added in v1.0.0
   - [Order](#order)
   - [Semigroup](#semigroup)
 - [utils](#utils)
+  - [at](#at)
+  - [charAt](#charat)
+  - [charCodeAt](#charcodeat)
+  - [codePointAt](#codepointat)
   - [concat](#concat)
   - [empty](#empty)
   - [endsWith](#endswith)
   - [endsWithPosition](#endswithposition)
   - [includes](#includes)
   - [includesWithPosition](#includeswithposition)
+  - [indexOf](#indexof)
   - [isEmpty](#isempty)
   - [isNonEmpty](#isnonempty)
+  - [lastIndexOf](#lastindexof)
   - [length](#length)
   - [linesWithSeparators](#lineswithseparators)
+  - [localeCompare](#localecompare)
+  - [match](#match)
+  - [matchAll](#matchall)
+  - [normalize](#normalize)
+  - [padEnd](#padend)
+  - [padStart](#padstart)
+  - [repeat](#repeat)
   - [replace](#replace)
+  - [replaceAll](#replaceall)
+  - [search](#search)
   - [slice](#slice)
   - [split](#split)
   - [startsWith](#startswith)
   - [startsWithPosition](#startswithposition)
   - [stripMargin](#stripmargin)
   - [stripMarginWith](#stripmarginwith)
+  - [substring](#substring)
   - [takeLeft](#takeleft)
   - [takeRight](#takeright)
+  - [toLocaleLowerCase](#tolocalelowercase)
+  - [toLocaleUpperCase](#tolocaleuppercase)
   - [toLowerCase](#tolowercase)
   - [toUpperCase](#touppercase)
   - [trim](#trim)
@@ -123,6 +141,84 @@ export declare const Semigroup: semigroup.Semigroup<string>
 Added in v1.0.0
 
 # utils
+
+## at
+
+**Signature**
+
+```ts
+export declare const at: {
+  (index: number): (self: string) => string | undefined
+  (self: string, index: number): string | undefined
+}
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.at('abc', 1), 'b')
+```
+
+Added in v1.0.0
+
+## charAt
+
+**Signature**
+
+```ts
+export declare const charAt: { (index: number): (self: string) => string; (self: string, index: number): string }
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.charAt('abc', 1), 'b')
+```
+
+Added in v1.0.0
+
+## charCodeAt
+
+**Signature**
+
+```ts
+export declare const charCodeAt: { (index: number): (self: string) => number; (self: string, index: number): number }
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.charCodeAt('abc', 1), 98)
+```
+
+Added in v1.0.0
+
+## codePointAt
+
+**Signature**
+
+```ts
+export declare const codePointAt: {
+  (index: number): (self: string) => number | undefined
+  (self: string, index: number): number | undefined
+}
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.codePointAt('abc', 1), 98)
+```
+
+Added in v1.0.0
 
 ## concat
 
@@ -240,6 +336,27 @@ assert.deepStrictEqual(S.includesWithPosition('abc', 'a', 1), false)
 
 Added in v1.0.0
 
+## indexOf
+
+**Signature**
+
+```ts
+export declare const indexOf: {
+  (searchString: string): (self: string) => number
+  (self: string, searchString: string): number
+}
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.indexOf('abbbc', 'b'), 1)
+```
+
+Added in v1.0.0
+
 ## isEmpty
 
 Test whether a `string` is empty.
@@ -269,6 +386,27 @@ Test whether a `string` is non empty.
 
 ```ts
 export declare const isNonEmpty: (self: string) => boolean
+```
+
+Added in v1.0.0
+
+## lastIndexOf
+
+**Signature**
+
+```ts
+export declare const lastIndexOf: {
+  (searchString: string): (self: string) => number
+  (self: string, searchString: string): number
+}
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.lastIndexOf('abbbc', 'b'), 3)
 ```
 
 Added in v1.0.0
@@ -306,6 +444,152 @@ export declare const linesWithSeparators: (s: string) => LinesIterator
 
 Added in v1.0.0
 
+## localeCompare
+
+**Signature**
+
+```ts
+export declare const localeCompare: {
+  (compareString: string): (self: string) => number
+  (self: string, compareString: string): number
+}
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.localeCompare('a', 'b'), -1)
+assert.deepStrictEqual(S.localeCompare('b', 'a'), 1)
+assert.deepStrictEqual(S.localeCompare('a', 'a'), 0)
+```
+
+Added in v1.0.0
+
+## match
+
+**Signature**
+
+```ts
+export declare const match: {
+  (regexp: RegExp | string): (self: string) => RegExpMatchArray | null
+  (self: string, regexp: RegExp | string): RegExpMatchArray | null
+}
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.ok(S.match('a', /a/)?.[0] === 'a')
+```
+
+Added in v1.0.0
+
+## matchAll
+
+**Signature**
+
+```ts
+export declare const matchAll: {
+  (regexp: RegExp): (self: string) => IterableIterator<RegExpMatchArray>
+  (self: string, regexp: RegExp): IterableIterator<RegExpMatchArray>
+}
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+S.matchAll('a', /a/g)
+```
+
+Added in v1.0.0
+
+## normalize
+
+**Signature**
+
+```ts
+export declare const normalize: {
+  (form: 'NFC' | 'NFD' | 'NFKC' | 'NFKD'): (self: string) => string
+  (self: string, form: 'NFC' | 'NFD' | 'NFKC' | 'NFKD'): string
+}
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.normalize('a', 'NFC'), 'a')
+```
+
+Added in v1.0.0
+
+## padEnd
+
+**Signature**
+
+```ts
+export declare const padEnd: {
+  (maxLength: number, fillString?: string): (self: string) => string
+  (self: string, maxLength: number, fillString?: string): string
+}
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.padEnd('a', 5), 'a    ')
+```
+
+Added in v1.0.0
+
+## padStart
+
+**Signature**
+
+```ts
+export declare const padStart: {
+  (maxLength: number, fillString?: string): (self: string) => string
+  (self: string, maxLength: number, fillString?: string): string
+}
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.padStart('a', 5), '    a')
+```
+
+Added in v1.0.0
+
+## repeat
+
+**Signature**
+
+```ts
+export declare const repeat: { (count: number): (self: string) => string; (self: string, count: number): string }
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.repeat('a', 3), 'aaa')
+```
+
+Added in v1.0.0
+
 ## replace
 
 **Signature**
@@ -324,6 +608,48 @@ import * as S from '@effect/data/String'
 import { pipe } from '@effect/data/Function'
 
 assert.deepStrictEqual(pipe('abc', S.replace('b', 'd')), 'adc')
+```
+
+Added in v1.0.0
+
+## replaceAll
+
+**Signature**
+
+```ts
+export declare const replaceAll: {
+  (searchValue: string | RegExp, replaceValue: string): (self: string) => string
+  (self: string, searchValue: string | RegExp, replaceValue: string): string
+}
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.replaceAll('ababb', 'b', 'c'), 'acacc')
+```
+
+Added in v1.0.0
+
+## search
+
+**Signature**
+
+```ts
+export declare const search: {
+  (regexp: RegExp | string): (self: string) => number
+  (self: string, regexp: RegExp | string): number
+}
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.search('ababb', 'b'), 1)
 ```
 
 Added in v1.0.0
@@ -449,6 +775,24 @@ export declare const stripMarginWith: ((marginChar: string) => (self: string) =>
 
 Added in v1.0.0
 
+## substring
+
+**Signature**
+
+```ts
+export declare const substring: { (start: number): (self: string) => string; (self: string, start: number): string }
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.substring('abcd', 1), 'bcd')
+```
+
+Added in v1.0.0
+
 ## takeLeft
 
 Keep the specified number of characters from the start of a string.
@@ -499,6 +843,48 @@ export declare const takeRight: { (n: number): (self: string) => string; (self: 
 import * as S from '@effect/data/String'
 
 assert.deepStrictEqual(S.takeRight('Hello World', 5), 'World')
+```
+
+Added in v1.0.0
+
+## toLocaleLowerCase
+
+**Signature**
+
+```ts
+export declare const toLocaleLowerCase: {
+  (locale?: string | Array<string>): (self: string) => string
+  (self: string, locale?: string | Array<string>): string
+}
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.toLocaleLowerCase('\u0130', 'tr'), 'i')
+```
+
+Added in v1.0.0
+
+## toLocaleUpperCase
+
+**Signature**
+
+```ts
+export declare const toLocaleUpperCase: {
+  (locale?: string | Array<string>): (self: string) => string
+  (self: string, locale?: string | Array<string>): string
+}
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+
+assert.deepStrictEqual(S.toLocaleUpperCase('i\u0307', 'lt-LT'), 'I')
 ```
 
 Added in v1.0.0

--- a/docs/modules/String.ts.md
+++ b/docs/modules/String.ts.md
@@ -504,7 +504,7 @@ export declare const matchAll: {
 ```ts
 import * as S from '@effect/data/String'
 
-S.matchAll('a', /a/g)
+assert.ok([...S.matchAll('ababb', /a/g)].length === 2)
 ```
 
 Added in v1.0.0

--- a/src/String.ts
+++ b/src/String.ts
@@ -422,7 +422,7 @@ export const match: {
  * @example
  * import * as S from '@effect/data/String'
  *
- * S.matchAll("a", /a/g)
+ * assert.ok([...S.matchAll("ababb", /a/g)].length === 2)
  *
  * @since 1.0.0
  */

--- a/src/String.ts
+++ b/src/String.ts
@@ -303,6 +303,246 @@ export const endsWith: {
  * @example
  * import * as S from '@effect/data/String'
  *
+ * assert.deepStrictEqual(S.charCodeAt("abc", 1), 98)
+ *
+ * @since 1.0.0
+ */
+export const charCodeAt: {
+  (index: number): (self: string) => number
+  (self: string, index: number): number
+} = dual(2, (self: string, index: number): number => self.charCodeAt(index))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.deepStrictEqual(S.substring("abcd", 1), "bcd")
+ *
+ * @since 1.0.0
+ */
+export const substring: {
+  (start: number): (self: string) => string
+  (self: string, start: number): string
+} = dual(2, (self: string, start: number): string => self.substring(start))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.deepStrictEqual(S.at("abc", 1), "b")
+ *
+ * @since 1.0.0
+ */
+export const at: {
+  (index: number): (self: string) => string | undefined
+  (self: string, index: number): string | undefined
+} = dual(2, (self: string, index: number): string | undefined => self.at(index))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.deepStrictEqual(S.charAt("abc", 1), "b")
+ *
+ * @since 1.0.0
+ */
+export const charAt: {
+  (index: number): (self: string) => string
+  (self: string, index: number): string
+} = dual(2, (self: string, index: number): string => self.charAt(index))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.deepStrictEqual(S.codePointAt("abc", 1), 98)
+ *
+ * @since 1.0.0
+ */
+export const codePointAt: {
+  (index: number): (self: string) => number | undefined
+  (self: string, index: number): number | undefined
+} = dual(2, (self: string, index: number): number | undefined => self.codePointAt(index))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.deepStrictEqual(S.indexOf("abbbc", "b"), 1)
+ *
+ * @since 1.0.0
+ */
+export const indexOf: {
+  (searchString: string): (self: string) => number
+  (self: string, searchString: string): number
+} = dual(2, (self: string, searchString: string): number => self.indexOf(searchString))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.deepStrictEqual(S.lastIndexOf("abbbc", "b"), 3)
+ *
+ * @since 1.0.0
+ */
+export const lastIndexOf: {
+  (searchString: string): (self: string) => number
+  (self: string, searchString: string): number
+} = dual(2, (self: string, searchString: string): number => self.lastIndexOf(searchString))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.deepStrictEqual(S.localeCompare("a", "b"), -1)
+ * assert.deepStrictEqual(S.localeCompare("b", "a"), 1)
+ * assert.deepStrictEqual(S.localeCompare("a", "a"), 0)
+ *
+ * @since 1.0.0
+ */
+export const localeCompare: {
+  (compareString: string): (self: string) => number
+  (self: string, compareString: string): number
+} = dual(2, (self: string, compareString: string): number => self.localeCompare(compareString))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.ok(S.match("a", /a/)?.[0] === "a")
+ *
+ * @since 1.0.0
+ */
+export const match: {
+  (regexp: RegExp | string): (self: string) => RegExpMatchArray | null
+  (self: string, regexp: RegExp | string): RegExpMatchArray | null
+} = dual(2, (self: string, regexp: RegExp | string): RegExpMatchArray | null => self.match(regexp))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * S.matchAll("a", /a/g)
+ *
+ * @since 1.0.0
+ */
+export const matchAll: {
+  (regexp: RegExp): (self: string) => IterableIterator<RegExpMatchArray>
+  (self: string, regexp: RegExp): IterableIterator<RegExpMatchArray>
+} = dual(2, (self: string, regexp: RegExp): IterableIterator<RegExpMatchArray> => self.matchAll(regexp))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.deepStrictEqual(S.normalize("a", "NFC"), "a")
+ *
+ * @since 1.0.0
+ */
+export const normalize: {
+  (form: "NFC" | "NFD" | "NFKC" | "NFKD"): (self: string) => string
+  (self: string, form: "NFC" | "NFD" | "NFKC" | "NFKD"): string
+} = dual(2, (self: string, form: "NFC" | "NFD" | "NFKC" | "NFKD"): string => self.normalize(form))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.deepStrictEqual(S.padEnd("a", 5), "a    ")
+ *
+ * @since 1.0.0
+ */
+export const padEnd: {
+  (maxLength: number, fillString?: string): (self: string) => string
+  (self: string, maxLength: number, fillString?: string): string
+} = dual(2, (self: string, maxLength: number, fillString?: string): string => self.padEnd(maxLength, fillString))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.deepStrictEqual(S.padStart("a", 5), "    a")
+ *
+ * @since 1.0.0
+ */
+export const padStart: {
+  (maxLength: number, fillString?: string): (self: string) => string
+  (self: string, maxLength: number, fillString?: string): string
+} = dual(2, (self: string, maxLength: number, fillString?: string): string => self.padStart(maxLength, fillString))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.deepStrictEqual(S.repeat("a", 3), "aaa")
+ *
+ * @since 1.0.0
+ */
+export const repeat: {
+  (count: number): (self: string) => string
+  (self: string, count: number): string
+} = dual(2, (self: string, count: number): string => self.repeat(count))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.deepStrictEqual(S.replaceAll("ababb", "b", "c"), "acacc")
+ *
+ * @since 1.0.0
+ */
+export const replaceAll: {
+  (searchValue: string | RegExp, replaceValue: string): (self: string) => string
+  (self: string, searchValue: string | RegExp, replaceValue: string): string
+} = dual(
+  3,
+  (self: string, searchValue: string | RegExp, replaceValue: string): string =>
+    self.replaceAll(searchValue, replaceValue)
+)
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.deepStrictEqual(S.search("ababb", "b"), 1)
+ *
+ * @since 1.0.0
+ */
+export const search: {
+  (regexp: RegExp | string): (self: string) => number
+  (self: string, regexp: RegExp | string): number
+} = dual(2, (self: string, regexp: RegExp | string): number => self.search(regexp))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.deepStrictEqual(S.toLocaleLowerCase("\u0130", "tr"), "i")
+ *
+ * @since 1.0.0
+ */
+export const toLocaleLowerCase: {
+  (locale?: string | Array<string>): (self: string) => string
+  (self: string, locale?: string | Array<string>): string
+} = dual(1, (self: string, locale?: string | Array<string>): string => self.toLocaleLowerCase(locale))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
+ * assert.deepStrictEqual(S.toLocaleUpperCase("i\u0307", "lt-LT"), "I")
+ *
+ * @since 1.0.0
+ */
+export const toLocaleUpperCase: {
+  (locale?: string | Array<string>): (self: string) => string
+  (self: string, locale?: string | Array<string>): string
+} = dual(1, (self: string, locale?: string | Array<string>): string => self.toLocaleUpperCase(locale))
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ *
  * assert.deepStrictEqual(S.endsWithPosition("abc", "b", 2), true)
  * assert.deepStrictEqual(S.endsWithPosition("abc", "c", 2), false)
  *

--- a/src/String.ts
+++ b/src/String.ts
@@ -302,242 +302,213 @@ export const endsWith: {
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.deepStrictEqual(S.charCodeAt("abc", 1), 98)
+ * assert.deepStrictEqual(pipe("abc", S.charCodeAt(1)), 98)
  *
  * @since 1.0.0
  */
-export const charCodeAt: {
-  (index: number): (self: string) => number
-  (self: string, index: number): number
-} = dual(2, (self: string, index: number): number => self.charCodeAt(index))
+export const charCodeAt = (index: number) => (self: string): number => self.charCodeAt(index)
 
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.deepStrictEqual(S.substring("abcd", 1), "bcd")
+ * assert.deepStrictEqual(pipe("abcd", S.substring(1)), "bcd")
+ * assert.deepStrictEqual(pipe("abcd", S.substring(1, 3)), "bc")
  *
  * @since 1.0.0
  */
-export const substring: {
-  (start: number): (self: string) => string
-  (self: string, start: number): string
-} = dual(2, (self: string, start: number): string => self.substring(start))
+export const substring = (start: number, end?: number) => (self: string): string => self.substring(start, end)
 
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.deepStrictEqual(S.at("abc", 1), "b")
+ * assert.deepStrictEqual(pipe("abc", S.at(1)), "b")
+ * assert.deepStrictEqual(pipe("abc", S.at(4)), undefined)
  *
  * @since 1.0.0
  */
-export const at: {
-  (index: number): (self: string) => string | undefined
-  (self: string, index: number): string | undefined
-} = dual(2, (self: string, index: number): string | undefined => self.at(index))
+export const at = (index: number) => (self: string): string | undefined => self.at(index)
 
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.deepStrictEqual(S.charAt("abc", 1), "b")
+ * assert.deepStrictEqual(pipe("abc", S.charAt(1)), "b")
  *
  * @since 1.0.0
  */
-export const charAt: {
-  (index: number): (self: string) => string
-  (self: string, index: number): string
-} = dual(2, (self: string, index: number): string => self.charAt(index))
+export const charAt = (index: number) => (self: string): string => self.charAt(index)
 
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.deepStrictEqual(S.codePointAt("abc", 1), 98)
+ * assert.deepStrictEqual(pipe("abc", S.codePointAt(1)), 98)
  *
  * @since 1.0.0
  */
-export const codePointAt: {
-  (index: number): (self: string) => number | undefined
-  (self: string, index: number): number | undefined
-} = dual(2, (self: string, index: number): number | undefined => self.codePointAt(index))
+export const codePointAt = (index: number) => (self: string): number | undefined => self.codePointAt(index)
 
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.deepStrictEqual(S.indexOf("abbbc", "b"), 1)
+ * assert.deepStrictEqual(pipe("abbbc", S.indexOf("b")), 1)
  *
  * @since 1.0.0
  */
-export const indexOf: {
-  (searchString: string): (self: string) => number
-  (self: string, searchString: string): number
-} = dual(2, (self: string, searchString: string): number => self.indexOf(searchString))
+export const indexOf = (searchString: string) => (self: string): number => self.indexOf(searchString)
 
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.deepStrictEqual(S.lastIndexOf("abbbc", "b"), 3)
+ * assert.deepStrictEqual(pipe("abbbc", S.lastIndexOf("b")), 3)
  *
  * @since 1.0.0
  */
-export const lastIndexOf: {
-  (searchString: string): (self: string) => number
-  (self: string, searchString: string): number
-} = dual(2, (self: string, searchString: string): number => self.lastIndexOf(searchString))
+export const lastIndexOf = (searchString: string) => (self: string): number => self.lastIndexOf(searchString)
 
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.deepStrictEqual(S.localeCompare("a", "b"), -1)
- * assert.deepStrictEqual(S.localeCompare("b", "a"), 1)
- * assert.deepStrictEqual(S.localeCompare("a", "a"), 0)
+ * assert.deepStrictEqual(pipe("a", S.localeCompare("b")), -1)
+ * assert.deepStrictEqual(pipe("b", S.localeCompare("a")), 1)
+ * assert.deepStrictEqual(pipe("a", S.localeCompare("a")), 0)
  *
  * @since 1.0.0
  */
-export const localeCompare: {
-  (compareString: string): (self: string) => number
-  (self: string, compareString: string): number
-} = dual(2, (self: string, compareString: string): number => self.localeCompare(compareString))
+export const localeCompare = (that: string, locales?: Array<string>, options?: Intl.CollatorOptions) =>
+  (self: string): number => self.localeCompare(that, locales, options)
+
+/**
+ * It is the `pipe`-able version of the native `match` method.
+ *
+ * @since 1.0.0
+ */
+export const match = (regexp: RegExp | string) => (self: string): RegExpMatchArray | null => self.match(regexp)
+
+/**
+ * It is the `pipe`-able version of the native `matchAll` method.
+ *
+ * @since 1.0.0
+ */
+export const matchAll = (regexp: RegExp) => (self: string): IterableIterator<RegExpMatchArray> => self.matchAll(regexp)
 
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.ok(S.match("a", /a/)?.[0] === "a")
+ * const str = "\u1E9B\u0323";
+ * assert.deepStrictEqual(pipe(str, S.normalize()), "\u1E9B\u0323")
+ * assert.deepStrictEqual(pipe(str, S.normalize("NFC")), "\u1E9B\u0323")
+ * assert.deepStrictEqual(pipe(str, S.normalize("NFD")), "\u017F\u0323\u0307")
+ * assert.deepStrictEqual(pipe(str, S.normalize("NFKC")), "\u1E69")
+ * assert.deepStrictEqual(pipe(str, S.normalize("NFKD")), "\u0073\u0323\u0307")
  *
  * @since 1.0.0
  */
-export const match: {
-  (regexp: RegExp | string): (self: string) => RegExpMatchArray | null
-  (self: string, regexp: RegExp | string): RegExpMatchArray | null
-} = dual(2, (self: string, regexp: RegExp | string): RegExpMatchArray | null => self.match(regexp))
+export const normalize = (form?: "NFC" | "NFD" | "NFKC" | "NFKD") => (self: string): string => self.normalize(form)
 
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.ok([...S.matchAll("ababb", /a/g)].length === 2)
+ * assert.deepStrictEqual(pipe("a", S.padEnd(5)), "a    ")
+ * assert.deepStrictEqual(pipe("a", S.padEnd(5, "_")), "a____")
  *
  * @since 1.0.0
  */
-export const matchAll: {
-  (regexp: RegExp): (self: string) => IterableIterator<RegExpMatchArray>
-  (self: string, regexp: RegExp): IterableIterator<RegExpMatchArray>
-} = dual(2, (self: string, regexp: RegExp): IterableIterator<RegExpMatchArray> => self.matchAll(regexp))
+export const padEnd = (maxLength: number, fillString?: string) =>
+  (self: string): string => self.padEnd(maxLength, fillString)
 
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.deepStrictEqual(S.normalize("a", "NFC"), "a")
+ * assert.deepStrictEqual(pipe("a", S.padStart(5)), "    a")
+ * assert.deepStrictEqual(pipe("a", S.padStart(5, "_")), "____a")
  *
  * @since 1.0.0
  */
-export const normalize: {
-  (form: "NFC" | "NFD" | "NFKC" | "NFKD"): (self: string) => string
-  (self: string, form: "NFC" | "NFD" | "NFKC" | "NFKD"): string
-} = dual(2, (self: string, form: "NFC" | "NFD" | "NFKC" | "NFKD"): string => self.normalize(form))
+export const padStart = (maxLength: number, fillString?: string) =>
+  (self: string): string => self.padStart(maxLength, fillString)
 
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.deepStrictEqual(S.padEnd("a", 5), "a    ")
+ * assert.deepStrictEqual(pipe("a", S.repeat(5)), "aaaaa")
  *
  * @since 1.0.0
  */
-export const padEnd: {
-  (maxLength: number, fillString?: string): (self: string) => string
-  (self: string, maxLength: number, fillString?: string): string
-} = dual(2, (self: string, maxLength: number, fillString?: string): string => self.padEnd(maxLength, fillString))
+export const repeat = (count: number) => (self: string): string => self.repeat(count)
 
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.deepStrictEqual(S.padStart("a", 5), "    a")
+ * assert.deepStrictEqual(pipe("ababb", S.replaceAll("b", "c")), "acacc")
+ * assert.deepStrictEqual(pipe("ababb", S.replaceAll(/ba/g, "cc")), "accbb")
  *
  * @since 1.0.0
  */
-export const padStart: {
-  (maxLength: number, fillString?: string): (self: string) => string
-  (self: string, maxLength: number, fillString?: string): string
-} = dual(2, (self: string, maxLength: number, fillString?: string): string => self.padStart(maxLength, fillString))
+export const replaceAll = (searchValue: string | RegExp, replaceValue: string) =>
+  (self: string): string => self.replaceAll(searchValue, replaceValue)
 
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.deepStrictEqual(S.repeat("a", 3), "aaa")
+ * assert.deepStrictEqual(pipe("ababb", S.search("b")), 1)
+ * assert.deepStrictEqual(pipe("ababb", S.search(/abb/)), 2)
  *
  * @since 1.0.0
  */
-export const repeat: {
-  (count: number): (self: string) => string
-  (self: string, count: number): string
-} = dual(2, (self: string, count: number): string => self.repeat(count))
+export const search = (regexp: RegExp | string) => (self: string): number => self.search(regexp)
 
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.deepStrictEqual(S.replaceAll("ababb", "b", "c"), "acacc")
+ * const str = "\u0130"
+ * assert.deepStrictEqual(pipe(str, S.toLocaleLowerCase("tr")), "i")
  *
  * @since 1.0.0
  */
-export const replaceAll: {
-  (searchValue: string | RegExp, replaceValue: string): (self: string) => string
-  (self: string, searchValue: string | RegExp, replaceValue: string): string
-} = dual(
-  3,
-  (self: string, searchValue: string | RegExp, replaceValue: string): string =>
-    self.replaceAll(searchValue, replaceValue)
-)
+export const toLocaleLowerCase = (locale?: string | Array<string>) =>
+  (self: string): string => self.toLocaleLowerCase(locale)
 
 /**
  * @example
  * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
  *
- * assert.deepStrictEqual(S.search("ababb", "b"), 1)
- *
- * @since 1.0.0
- */
-export const search: {
-  (regexp: RegExp | string): (self: string) => number
-  (self: string, regexp: RegExp | string): number
-} = dual(2, (self: string, regexp: RegExp | string): number => self.search(regexp))
-
-/**
- * @example
- * import * as S from '@effect/data/String'
- *
- * assert.deepStrictEqual(S.toLocaleLowerCase("\u0130", "tr"), "i")
+ * const str = "i\u0307"
+ * assert.deepStrictEqual(pipe(str, S.toLocaleUpperCase("lt-LT")), "I")
  *
  * @since 1.0.0
  */
-export const toLocaleLowerCase: {
-  (locale?: string | Array<string>): (self: string) => string
-  (self: string, locale?: string | Array<string>): string
-} = dual(1, (self: string, locale?: string | Array<string>): string => self.toLocaleLowerCase(locale))
-
-/**
- * @example
- * import * as S from '@effect/data/String'
- *
- * assert.deepStrictEqual(S.toLocaleUpperCase("i\u0307", "lt-LT"), "I")
- *
- * @since 1.0.0
- */
-export const toLocaleUpperCase: {
-  (locale?: string | Array<string>): (self: string) => string
-  (self: string, locale?: string | Array<string>): string
-} = dual(1, (self: string, locale?: string | Array<string>): string => self.toLocaleUpperCase(locale))
+export const toLocaleUpperCase = (locale?: string | Array<string>) =>
+  (self: string): string => self.toLocaleUpperCase(locale)
 
 /**
  * @example

--- a/src/String.ts
+++ b/src/String.ts
@@ -410,10 +410,7 @@ export const lastIndexOf = (searchString: string) =>
  * @since 1.0.0
  */
 export const localeCompare = (that: string, locales?: Array<string>, options?: Intl.CollatorOptions) =>
-  (self: string): Ordering.Ordering => {
-    const result = self.localeCompare(that, locales, options)
-    return result === 0 ? 0 : result > 0 ? 1 : -1
-  }
+  (self: string): Ordering.Ordering => number.sign(self.localeCompare(that, locales, options))
 
 /**
  * It is the `pipe`-able version of the native `match` method.

--- a/test/String.ts
+++ b/test/String.ts
@@ -124,95 +124,95 @@ describe.concurrent("String", () => {
   })
 
   it("charCodeAt", () => {
-    expect(S.charCodeAt("abc", 1)).toBe(98)
+    expect(pipe("abc", S.charCodeAt(1))).toBe(98)
   })
 
   it("substring", () => {
-    expect(S.substring("abcd", 1)).toBe("bcd")
+    expect(pipe("abcd", S.substring(1))).toBe("bcd")
+    expect(pipe("abcd", S.substring(1, 3))).toBe("bc")
   })
 
   it("at", () => {
-    expect(S.at("abc", 1)).toBe("b")
-    expect(S.at("abc", 4)).toBe(undefined)
+    expect(pipe("abc", S.at(1))).toBe("b")
+    expect(pipe("abc", S.at(4))).toBe(undefined)
   })
 
   it("charAt", () => {
-    expect(S.charAt("abc", 1)).toBe("b")
+    expect(pipe("abc", S.charAt(1))).toBe("b")
   })
 
   it("codePointAt", () => {
-    expect(S.codePointAt("abc", 1)).toBe(98)
-    expect(S.codePointAt("abc", 4)).toBe(undefined)
+    expect(pipe("abc", S.codePointAt(1))).toBe(98)
+    expect(pipe("abc", S.codePointAt(4))).toBe(undefined)
   })
 
   it("indexOf", () => {
-    expect(S.indexOf("abbbc", "b")).toBe(1)
-    expect(S.indexOf("abbbc", "d")).toBe(-1)
+    expect(pipe("abbbc", S.indexOf("b"))).toBe(1)
+    expect(pipe("abbbc", S.indexOf("d"))).toBe(-1)
   })
 
   it("lastIndexOf", () => {
-    expect(S.lastIndexOf("abbbc", "b")).toBe(3)
-    expect(S.lastIndexOf("abbbc", "d")).toBe(-1)
+    expect(pipe("abbbc", S.lastIndexOf("b"))).toBe(3)
+    expect(pipe("abbbc", S.lastIndexOf("d"))).toBe(-1)
   })
 
   it("localeCompare", () => {
-    expect(S.localeCompare("a", "b")).toBeLessThanOrEqual(-1)
-    expect(S.localeCompare("b", "a")).toBeGreaterThanOrEqual(1)
-    expect(S.localeCompare("a", "a")).toBe(0)
+    expect(pipe("a", S.localeCompare("b"))).toBeLessThanOrEqual(-1)
+    expect(pipe("b", S.localeCompare("a"))).toBeGreaterThanOrEqual(1)
+    expect(pipe("a", S.localeCompare("a"))).toBe(0)
   })
 
   it("match", () => {
-    expect(S.match("a", /a/)).toHaveProperty("0", "a")
-    expect(S.match("a", /b/)).toBe(null)
+    expect(pipe("a", S.match(/a/))).toContainEqual("a")
+    expect(pipe("a", S.match(/b/))).toBe(null)
   })
 
   it("matchAll", () => {
-    expect([...S.matchAll("apple, banana", /a[pn]/g)]).toHaveLength(3)
-    expect([...S.matchAll("apple, banana", /c/g)]).toHaveLength(0)
+    expect(Array.from(pipe("apple, banana", S.matchAll(/a[pn]/g)))).toHaveLength(3)
+    expect(Array.from(pipe("apple, banana", S.matchAll(/c/g)))).toHaveLength(0)
   })
 
   it("normalize", () => {
-    expect(S.normalize("a\u0300", "NFD")).toBe("a\u0300")
-    expect(S.normalize("a\u0300", "NFC")).toBe("à")
-    expect(S.normalize("a\u0300", "NFKC")).toBe("à")
-    expect(S.normalize("a\u0300", "NFKD")).toBe("a\u0300")
+    const str = "\u1E9B\u0323"
+    expect(pipe(str, S.normalize())).toBe("\u1E9B\u0323")
+    expect(pipe(str, S.normalize("NFC"))).toBe("\u1E9B\u0323")
+    expect(pipe(str, S.normalize("NFD"))).toBe("\u017F\u0323\u0307")
+    expect(pipe(str, S.normalize("NFKC"))).toBe("\u1E69")
+    expect(pipe(str, S.normalize("NFKD"))).toBe("\u0073\u0323\u0307")
   })
 
   it("padEnd", () => {
-    expect(S.padEnd("a", 5)).toBe("a    ")
-    expect(S.padEnd("a", 5, "b")).toBe("abbbb")
+    expect(pipe("a", S.padEnd(5))).toBe("a    ")
+    expect(pipe("a", S.padEnd(5, "_"))).toBe("a____")
   })
 
   it("padStart", () => {
-    expect(S.padStart("a", 5)).toBe("    a")
-    expect(S.padStart("a", 5, "b")).toBe("bbbba")
+    expect(pipe("a", S.padStart(5))).toBe("    a")
+    expect(pipe("a", S.padStart(5, "_"))).toBe("____a")
   })
 
   it("repeat", () => {
-    expect(S.repeat("a", 3)).toBe("aaa")
+    expect(pipe("a", S.repeat(3))).toBe("aaa")
   })
 
   it("replaceAll", () => {
-    expect(S.replaceAll("cake bake lake take", "ake", "ap")).toBe("cap bap lap tap")
-    expect(S.replaceAll("cake basket lapid taken", /a\w+/g, "ap")).toBe("cap bap lap tap")
+    expect(pipe("ababb", S.replaceAll("b", "c"))).toBe("acacc")
+    expect(pipe("ababb", S.replaceAll(/ba/g, "cc"))).toBe("accbb")
   })
 
   it("search", () => {
-    expect(S.search("abc", "ab")).toBe(0)
-    expect(S.search("abc", /b/)).toBe(1)
-    expect(S.search("abc", /d/)).toBe(-1)
-    expect(S.search("abc", "d")).toBe(-1)
+    expect(pipe("ababb", S.search("b"))).toBe(1)
+    expect(pipe("ababb", S.search(/abb/))).toBe(2)
   })
 
   it("toLocaleLowerCase", () => {
     const locales = ["tr", "TR", "tr-TR", "tr-u-co-search", "tr-x-turkish"]
-    expect(S.toLocaleLowerCase("\u0130")).not.toBe("i")
-    expect(S.toLocaleLowerCase("\u0130", locales)).toBe("i")
+    expect(pipe("\u0130", S.toLocaleLowerCase(locales))).toBe("i")
   })
 
   it("toLocaleUpperCase", () => {
     const locales = ["lt", "LT", "lt-LT", "lt-u-co-phonebk", "lt-x-lietuva"]
-    expect(S.toLocaleUpperCase("i\u0307", locales)).toBe("I")
+    expect(pipe("i\u0307", S.toLocaleUpperCase(locales))).toBe("I")
   })
 
   describe.concurrent("takeLeft", () => {

--- a/test/String.ts
+++ b/test/String.ts
@@ -1,4 +1,5 @@
 import { pipe } from "@effect/data/Function"
+import * as Option from "@effect/data/Option"
 import * as S from "@effect/data/String"
 import { deepStrictEqual } from "@effect/data/test/util"
 import * as Order from "@effect/data/typeclass/Order"
@@ -124,7 +125,8 @@ describe.concurrent("String", () => {
   })
 
   it("charCodeAt", () => {
-    expect(pipe("abc", S.charCodeAt(1))).toBe(98)
+    expect(pipe("abc", S.charCodeAt(1))).toStrictEqual(Option.some(98))
+    expect(pipe("abc", S.charCodeAt(4))).toStrictEqual(Option.none())
   })
 
   it("substring", () => {
@@ -133,38 +135,39 @@ describe.concurrent("String", () => {
   })
 
   it("at", () => {
-    expect(pipe("abc", S.at(1))).toBe("b")
-    expect(pipe("abc", S.at(4))).toBe(undefined)
+    expect(pipe("abc", S.at(1))).toStrictEqual(Option.some("b"))
+    expect(pipe("abc", S.at(4))).toStrictEqual(Option.none())
   })
 
   it("charAt", () => {
-    expect(pipe("abc", S.charAt(1))).toBe("b")
+    expect(pipe("abc", S.charAt(1))).toStrictEqual(Option.some("b"))
+    expect(pipe("abc", S.charAt(4))).toStrictEqual(Option.none())
   })
 
   it("codePointAt", () => {
-    expect(pipe("abc", S.codePointAt(1))).toBe(98)
-    expect(pipe("abc", S.codePointAt(4))).toBe(undefined)
+    expect(pipe("abc", S.codePointAt(1))).toStrictEqual(Option.some(98))
+    expect(pipe("abc", S.codePointAt(4))).toStrictEqual(Option.none())
   })
 
   it("indexOf", () => {
-    expect(pipe("abbbc", S.indexOf("b"))).toBe(1)
-    expect(pipe("abbbc", S.indexOf("d"))).toBe(-1)
+    expect(pipe("abbbc", S.indexOf("b"))).toStrictEqual(Option.some(1))
+    expect(pipe("abbbc", S.indexOf("d"))).toStrictEqual(Option.none())
   })
 
   it("lastIndexOf", () => {
-    expect(pipe("abbbc", S.lastIndexOf("b"))).toBe(3)
-    expect(pipe("abbbc", S.lastIndexOf("d"))).toBe(-1)
+    expect(pipe("abbbc", S.lastIndexOf("b"))).toStrictEqual(Option.some(3))
+    expect(pipe("abbbc", S.lastIndexOf("d"))).toStrictEqual(Option.none())
   })
 
   it("localeCompare", () => {
-    expect(pipe("a", S.localeCompare("b"))).toBeLessThanOrEqual(-1)
-    expect(pipe("b", S.localeCompare("a"))).toBeGreaterThanOrEqual(1)
+    expect(pipe("a", S.localeCompare("b"))).toBe(-1)
+    expect(pipe("b", S.localeCompare("a"))).toBe(1)
     expect(pipe("a", S.localeCompare("a"))).toBe(0)
   })
 
   it("match", () => {
-    expect(pipe("a", S.match(/a/))).toContainEqual("a")
-    expect(pipe("a", S.match(/b/))).toBe(null)
+    expect(pipe("a", S.match(/a/))).toStrictEqual(Option.some(expect.arrayContaining(["a"])))
+    expect(pipe("a", S.match(/b/))).toStrictEqual(Option.none())
   })
 
   it("matchAll", () => {
@@ -201,8 +204,9 @@ describe.concurrent("String", () => {
   })
 
   it("search", () => {
-    expect(pipe("ababb", S.search("b"))).toBe(1)
-    expect(pipe("ababb", S.search(/abb/))).toBe(2)
+    expect(pipe("ababb", S.search("b"))).toStrictEqual(Option.some(1))
+    expect(pipe("ababb", S.search(/abb/))).toStrictEqual(Option.some(2))
+    expect(pipe("ababb", S.search(/c/))).toStrictEqual(Option.none())
   })
 
   it("toLocaleLowerCase", () => {

--- a/test/String.ts
+++ b/test/String.ts
@@ -123,6 +123,98 @@ describe.concurrent("String", () => {
     deepStrictEqual(pipe("abcd", S.slice(1, 3)), "bc")
   })
 
+  it("charCodeAt", () => {
+    expect(S.charCodeAt("abc", 1)).toBe(98)
+  })
+
+  it("substring", () => {
+    expect(S.substring("abcd", 1)).toBe("bcd")
+  })
+
+  it("at", () => {
+    expect(S.at("abc", 1)).toBe("b")
+    expect(S.at("abc", 4)).toBe(undefined)
+  })
+
+  it("charAt", () => {
+    expect(S.charAt("abc", 1)).toBe("b")
+  })
+
+  it("codePointAt", () => {
+    expect(S.codePointAt("abc", 1)).toBe(98)
+    expect(S.codePointAt("abc", 4)).toBe(undefined)
+  })
+
+  it("indexOf", () => {
+    expect(S.indexOf("abbbc", "b")).toBe(1)
+    expect(S.indexOf("abbbc", "d")).toBe(-1)
+  })
+
+  it("lastIndexOf", () => {
+    expect(S.lastIndexOf("abbbc", "b")).toBe(3)
+    expect(S.lastIndexOf("abbbc", "d")).toBe(-1)
+  })
+
+  it("localeCompare", () => {
+    expect(S.localeCompare("a", "b")).toBeLessThanOrEqual(-1)
+    expect(S.localeCompare("b", "a")).toBeGreaterThanOrEqual(1)
+    expect(S.localeCompare("a", "a")).toBe(0)
+  })
+
+  it("match", () => {
+    expect(S.match("a", /a/)).toHaveProperty("0", "a")
+    expect(S.match("a", /b/)).toBe(null)
+  })
+
+  it("matchAll", () => {
+    expect([...S.matchAll("apple, banana", /a[pn]/g)]).toHaveLength(3)
+    expect([...S.matchAll("apple, banana", /c/g)]).toHaveLength(0)
+  })
+
+  it("normalize", () => {
+    expect(S.normalize("a\u0300", "NFD")).toBe("a\u0300")
+    expect(S.normalize("a\u0300", "NFC")).toBe("à")
+    expect(S.normalize("a\u0300", "NFKC")).toBe("à")
+    expect(S.normalize("a\u0300", "NFKD")).toBe("a\u0300")
+  })
+
+  it("padEnd", () => {
+    expect(S.padEnd("a", 5)).toBe("a    ")
+    expect(S.padEnd("a", 5, "b")).toBe("abbbb")
+  })
+
+  it("padStart", () => {
+    expect(S.padStart("a", 5)).toBe("    a")
+    expect(S.padStart("a", 5, "b")).toBe("bbbba")
+  })
+
+  it("repeat", () => {
+    expect(S.repeat("a", 3)).toBe("aaa")
+  })
+
+  it("replaceAll", () => {
+    expect(S.replaceAll("cake bake lake take", "ake", "ap")).toBe("cap bap lap tap")
+    expect(S.replaceAll("cake basket lapid taken", /a\w+/g, "ap")).toBe("cap bap lap tap")
+  })
+
+  it("search", () => {
+    expect(S.search("abc", "ab")).toBe(0)
+    expect(S.search("abc", /b/)).toBe(1)
+    expect(S.search("abc", /d/)).toBe(-1)
+    expect(S.search("abc", "d")).toBe(-1)
+  })
+
+  it("toLocaleLowerCase", () => {
+    const locales = ["tr", "TR", "tr-TR", "tr-u-co-search", "tr-x-turkish"]
+    expect(S.toLocaleLowerCase("\u0130")).not.toBe("i")
+    expect(S.toLocaleLowerCase("\u0130", locales)).toBe("i")
+  })
+
+  it("toLocaleUpperCase", () => {
+    const locales = ["lt", "LT", "lt-LT", "lt-u-co-phonebk", "lt-x-lietuva"]
+    expect(S.toLocaleUpperCase("i\u0307", locales)).toBe("I")
+  })
+
   describe.concurrent("takeLeft", () => {
     it("should take the specified number of characters from the left side of a string", () => {
       expect(S.takeLeft("Hello, World!", 7)).toBe("Hello, ")


### PR DESCRIPTION
Add missing functions in String module. Resolve #360

- [x] Add missing functions with test cases.
- [x] Update `docs/modules/String.ts.md` (via `pnpm build && pnpm run docs`)
- [x] Add changesets

Question: Some functions have optional arguments and I considered adding some functions for that like: 
- `substring` → `substringWithEnd`
- `indexOf` → `indexOfWithPosition`

Is it the right thing to do, or should it be postponed until later as needed? @gcanti 