### PR TITLE
feat: extended Foldable typeclass

### DIFF
--- a/.changeset/serious-games-dream.md
+++ b/.changeset/serious-games-dream.md
@@ -1,0 +1,5 @@
+---
+"@effect/data": patch
+---
+
+feat: extended Foldable typeclass

--- a/src/typeclass/Foldable.ts
+++ b/src/typeclass/Foldable.ts
@@ -5,6 +5,7 @@
 import { dual, identity } from "@effect/data/Function"
 import type { Kind, TypeClass, TypeLambda } from "@effect/data/HKT"
 import type { Coproduct } from "@effect/data/typeclass/Coproduct"
+import type { Equivalence } from "@effect/data/typeclass/Equivalence"
 import type { Monad } from "@effect/data/typeclass/Monad"
 import type { Monoid } from "@effect/data/typeclass/Monoid"
 
@@ -110,3 +111,91 @@ export const coproductMapKind = <F extends TypeLambda>(F: Foldable<F>) =>
       self: Kind<F, FR, FO, FE, A>,
       f: (a: A) => Kind<G, R, O, E, B>
     ): Kind<G, R, O, E, B> => F.reduce(self, G.zero(), (gb: Kind<G, R, O, E, B>, a) => G.coproduct(gb, f(a))))
+
+/**
+ * @since 1.0.0
+ * @category utils
+ */
+export const length = <F extends TypeLambda>(F: Foldable<F>): <R, O, E, A>(_: Kind<F, R, O, E, A>) => number =>
+  F.reduce(0, (b) => b + 1)
+
+/**
+ * @since 1.0.0
+ * @category utils
+ */
+export const contains = <F extends TypeLambda>(F: Foldable<F>) =>
+  <A>(eq: Equivalence<A>): {
+    (that: A): <R, O, E>(self: Kind<F, R, O, E, A>) => boolean
+    <R, O, E>(self: Kind<F, R, O, E, A>, that: A): boolean
+  } =>
+    dual(
+      2,
+      <R, O, E>(self: Kind<F, R, O, E, A>, that: A) => F.reduce<A, boolean>(false, (res, a) => res || eq(a, that))(self)
+    )
+
+/**
+ * @since 1.0.0
+ * @category math
+ */
+export const isEmpty = <F extends TypeLambda, R, O, E, A>(F: Foldable<F>): (_: Kind<F, R, O, E, A>) => boolean =>
+  F.reduce<A, boolean>(true, () => false)
+
+/**
+ * @since 1.0.0
+ * @category math
+ */
+export const sum = <F extends TypeLambda, R, O, E>(F: Foldable<F>): (_: Kind<F, R, O, E, number>) => number =>
+  F.reduce<number, number>(0, (b, a) => b + a)
+
+/**
+ * @since 1.0.0
+ * @category math
+ */
+export const sumBigint = <F extends TypeLambda, R, O, E>(F: Foldable<F>): (_: Kind<F, R, O, E, bigint>) => bigint =>
+  F.reduce<bigint, bigint>(0n, (b, a) => b + a)
+
+/**
+ * @since 1.0.0
+ * @category math
+ */
+export const product = <F extends TypeLambda, R, O, E>(F: Foldable<F>): (_: Kind<F, R, O, E, number>) => number =>
+  F.reduce<number, number>(1, (b, a) => b * a)
+
+/**
+ * @since 1.0.0
+ * @category math
+ */
+export const productBigint = <F extends TypeLambda, R, O, E>(F: Foldable<F>): (_: Kind<F, R, O, E, bigint>) => bigint =>
+  F.reduce<bigint, bigint>(1n, (b, a) => b * a)
+
+/**
+ * @since 1.0.0
+ * @category boolean
+ */
+export const and = <F extends TypeLambda, R, O, E>(F: Foldable<F>): (_: Kind<F, R, O, E, boolean>) => boolean =>
+  F.reduce<boolean, boolean>(true, (b, a) => a && b)
+
+/**
+ * @since 1.0.0
+ * @category boolean
+ */
+export const or = <F extends TypeLambda, R, O, E>(F: Foldable<F>): (_: Kind<F, R, O, E, boolean>) => boolean =>
+  F.reduce<boolean, boolean>(false, (b, a) => a || b)
+
+/**
+ * @since 1.0.0
+ * @category predicate
+ */
+export const every = <F extends TypeLambda, R, O, E>(
+  F: Foldable<F>
+): <A>(fn: (_: A) => boolean) => (_: Kind<F, R, O, E, A>) => boolean =>
+  <A>(fn: (_: A) => boolean) => F.reduce<A, boolean>(true, (b, a) => fn(a) && b)
+
+/**
+ * @since 1.0.0
+ * @category predicate
+ */
+export const any = <F extends TypeLambda, R, O, E>(
+  F: Foldable<F>
+): <A>(fn: (_: A) => boolean) => (_: Kind<F, R, O, E, A>) => boolean =>
+  <A>(fn: (_: A) => boolean) => F.reduce<A, boolean>(false, (b, a) => fn(a) || b)

--- a/test/typeclass/Foldable.ts
+++ b/test/typeclass/Foldable.ts
@@ -55,4 +55,98 @@ describe.concurrent("Foldable", () => {
       O.some("a")
     )
   })
+
+  it("length", () => {
+    const length = _.length(RA.Foldable)
+    U.deepStrictEqual(pipe([], length), 0)
+    U.deepStrictEqual(pipe([1], length), 1)
+    U.deepStrictEqual(pipe([1, 2], length), 2)
+  })
+
+  it("isEmpty", () => {
+    const isEmpty = _.isEmpty(RA.Foldable)
+    U.deepStrictEqual(pipe([], isEmpty), true)
+    U.deepStrictEqual(pipe([1], isEmpty), false)
+    U.deepStrictEqual(pipe([""], isEmpty), false)
+  })
+
+  it("contains", () => {
+    const contains = _.contains(RA.Foldable)(N.Equivalence)
+    U.deepStrictEqual(pipe([], contains(1)), false)
+    U.deepStrictEqual(pipe([0], contains(1)), false)
+    U.deepStrictEqual(contains([0, 1], 1), true)
+    U.deepStrictEqual(contains([3, 2, 1], 1), true)
+  })
+
+  it("sum", () => {
+    const sum = _.sum(RA.Foldable)
+    U.deepStrictEqual(pipe([], sum), 0)
+    U.deepStrictEqual(pipe([0], sum), 0)
+    U.deepStrictEqual(pipe([1], sum), 1)
+    U.deepStrictEqual(pipe([1, 2], sum), 3)
+  })
+
+  it("sumBigint", () => {
+    const sumBigint = _.sumBigint(RA.Foldable)
+    U.deepStrictEqual(pipe([], sumBigint), 0n)
+    U.deepStrictEqual(pipe([0n], sumBigint), 0n)
+    U.deepStrictEqual(pipe([1n], sumBigint), 1n)
+    U.deepStrictEqual(pipe([1n, 2n], sumBigint), 3n)
+  })
+
+  it("product", () => {
+    const product = _.product(RA.Foldable)
+    U.deepStrictEqual(pipe([], product), 1)
+    U.deepStrictEqual(pipe([0], product), 0)
+    U.deepStrictEqual(pipe([1], product), 1)
+    U.deepStrictEqual(pipe([1, 2], product), 2)
+  })
+
+  it("productBigint", () => {
+    const productBigint = _.productBigint(RA.Foldable)
+    U.deepStrictEqual(pipe([], productBigint), 1n)
+    U.deepStrictEqual(pipe([0n], productBigint), 0n)
+    U.deepStrictEqual(pipe([1n], productBigint), 1n)
+    U.deepStrictEqual(pipe([1n, 2n], productBigint), 2n)
+  })
+
+  it("and", () => {
+    const and = _.and(RA.Foldable)
+    U.deepStrictEqual(pipe([], and), true)
+    U.deepStrictEqual(pipe([true], and), true)
+    U.deepStrictEqual(pipe([false], and), false)
+    U.deepStrictEqual(pipe([true, false], and), false)
+    U.deepStrictEqual(pipe([true, true], and), true)
+  })
+
+  it("or", () => {
+    const or = _.or(RA.Foldable)
+    U.deepStrictEqual(pipe([], or), false)
+    U.deepStrictEqual(pipe([true], or), true)
+    U.deepStrictEqual(pipe([false], or), false)
+    U.deepStrictEqual(pipe([true, false], or), true)
+    U.deepStrictEqual(pipe([true, true], or), true)
+  })
+
+  it("every", () => {
+    const every = _.every(RA.Foldable)
+    const isEven = (n: number) => n % 2 === 0
+
+    U.deepStrictEqual(pipe([], every(isEven)), true)
+    U.deepStrictEqual(pipe([2], every(isEven)), true)
+    U.deepStrictEqual(pipe([1], every(isEven)), false)
+    U.deepStrictEqual(pipe([1, 2], every(isEven)), false)
+    U.deepStrictEqual(pipe([2, 4], every(isEven)), true)
+  })
+
+  it("any", () => {
+    const any = _.any(RA.Foldable)
+    const isEven = (n: number) => n % 2 === 0
+
+    U.deepStrictEqual(pipe([], any(isEven)), false)
+    U.deepStrictEqual(pipe([2], any(isEven)), true)
+    U.deepStrictEqual(pipe([1], any(isEven)), false)
+    U.deepStrictEqual(pipe([1, 2], any(isEven)), true)
+    U.deepStrictEqual(pipe([1, 2, 3], any(isEven)), true)
+  })
 })


### PR DESCRIPTION
Added utility functions to the Functor typeclass for handling wrapped values. See also, https://hackage.haskell.org/package/base-4.18.0.0/docs/Data-Foldable.html#t:Foldable

Also, let me know if I should recreate this over in the @effect/typeclass repo. 