### PR TITLE
String: Type-level helpers for more accurate string types 

### DIFF
--- a/.changeset/lucky-melons-rule.md
+++ b/.changeset/lucky-melons-rule.md
@@ -1,5 +1,5 @@
 ---
-"@effect/data": minor
+"@effect/data": patch
 ---
 
 Add type-level helpers to String for working with string literal types

--- a/.changeset/lucky-melons-rule.md
+++ b/.changeset/lucky-melons-rule.md
@@ -1,0 +1,5 @@
+---
+"@effect/data": minor
+---
+
+Add type-level helpers to String for working with string literal types

--- a/docs/modules/String.ts.md
+++ b/docs/modules/String.ts.md
@@ -22,7 +22,12 @@ Added in v1.0.0
   - [Equivalence](#equivalence)
   - [Order](#order)
 - [utils](#utils)
+  - [Concat (type alias)](#concat-type-alias)
+  - [Trim (type alias)](#trim-type-alias)
+  - [TrimEnd (type alias)](#trimend-type-alias)
+  - [TrimStart (type alias)](#trimstart-type-alias)
   - [at](#at)
+  - [capitalize](#capitalize)
   - [charAt](#charat)
   - [charCodeAt](#charcodeat)
   - [codePointAt](#codepointat)
@@ -61,6 +66,7 @@ Added in v1.0.0
   - [trim](#trim)
   - [trimEnd](#trimend)
   - [trimStart](#trimstart)
+  - [uncapitalize](#uncapitalize)
 
 ---
 
@@ -111,6 +117,64 @@ Added in v1.0.0
 
 # utils
 
+## Concat (type alias)
+
+Concatenates two strings at the type level.
+
+**Signature**
+
+```ts
+export type Concat<A extends string, B extends string> = `${A}${B}`
+```
+
+Added in v1.0.0
+
+## Trim (type alias)
+
+**Signature**
+
+```ts
+export type Trim<A extends string> = TrimEnd<TrimStart<A>>
+```
+
+Added in v1.0.0
+
+## TrimEnd (type alias)
+
+**Signature**
+
+```ts
+export type TrimEnd<A extends string> = A extends `${infer B} `
+  ? TrimEnd<B>
+  : A extends `${infer B}\n`
+  ? TrimEnd<B>
+  : A extends `${infer B}\t`
+  ? TrimEnd<B>
+  : A extends `${infer B}\r`
+  ? TrimEnd<B>
+  : A
+```
+
+Added in v1.0.0
+
+## TrimStart (type alias)
+
+**Signature**
+
+```ts
+export type TrimStart<A extends string> = A extends ` ${infer B}`
+  ? TrimStart<B>
+  : A extends `\n${infer B}`
+  ? TrimStart<B>
+  : A extends `\t${infer B}`
+  ? TrimStart<B>
+  : A extends `\r${infer B}`
+  ? TrimStart<B>
+  : A
+```
+
+Added in v1.0.0
+
 ## at
 
 **Signature**
@@ -131,6 +195,25 @@ import { pipe } from '@effect/data/Function'
 
 assert.deepStrictEqual(pipe('abc', S.at(1)), Option.some('b'))
 assert.deepStrictEqual(pipe('abc', S.at(4)), Option.none())
+```
+
+Added in v1.0.0
+
+## capitalize
+
+**Signature**
+
+```ts
+export declare const capitalize: <T extends string>(self: T) => Capitalize<T>
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
+
+assert.deepStrictEqual(pipe('abc', S.capitalize), 'Abc')
 ```
 
 Added in v1.0.0
@@ -208,10 +291,15 @@ Added in v1.0.0
 
 ## concat
 
+Concatenates two strings at runtime.
+
 **Signature**
 
 ```ts
-export declare const concat: { (that: string): (self: string) => string; (self: string, that: string): string }
+export declare const concat: {
+  <B extends string>(that: B): <A extends string>(self: A) => `${A}${B}`
+  <A extends string, B extends string>(self: A, that: B): `${A}${B}`
+}
 ```
 
 Added in v1.0.0
@@ -755,7 +843,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const toLowerCase: (self: string) => string
+export declare const toLowerCase: <T extends string>(self: T) => Lowercase<T>
 ```
 
 **Example**
@@ -774,7 +862,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const toUpperCase: (self: string) => string
+export declare const toUpperCase: <S extends string>(self: S) => Uppercase<S>
 ```
 
 **Example**
@@ -793,7 +881,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const trim: (self: string) => string
+export declare const trim: <A extends string>(self: A) => TrimEnd<TrimStart<A>>
 ```
 
 **Example**
@@ -811,7 +899,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const trimEnd: (self: string) => string
+export declare const trimEnd: <A extends string>(self: A) => TrimEnd<A>
 ```
 
 **Example**
@@ -829,7 +917,7 @@ Added in v1.0.0
 **Signature**
 
 ```ts
-export declare const trimStart: (self: string) => string
+export declare const trimStart: <A extends string>(self: A) => TrimStart<A>
 ```
 
 **Example**
@@ -838,6 +926,25 @@ export declare const trimStart: (self: string) => string
 import * as S from '@effect/data/String'
 
 assert.deepStrictEqual(S.trimStart(' a '), 'a ')
+```
+
+Added in v1.0.0
+
+## uncapitalize
+
+**Signature**
+
+```ts
+export declare const uncapitalize: <T extends string>(self: T) => Uncapitalize<T>
+```
+
+**Example**
+
+```ts
+import * as S from '@effect/data/String'
+import { pipe } from '@effect/data/Function'
+
+assert.deepStrictEqual(pipe('ABC', S.uncapitalize), 'aBC')
 ```
 
 Added in v1.0.0

--- a/dtslint/String.ts
+++ b/dtslint/String.ts
@@ -1,5 +1,47 @@
 import * as S from '@effect/data/String'
 
+// -----------------------------------------------------------------------------
+// apis
+// -----------------------------------------------------------------------------
+
+// $ExpectType "FooBar"
+S.concat(S.capitalize("foo"), S.capitalize("bar"))
+
+// $ExpectType "FOO"
+S.toUpperCase("foo")
+
+// $ExpectType "bar"
+S.toLowerCase("BAR")
+
+// $ExpectType "Foo"
+S.capitalize("foo")
+
+// $ExpectType "bAR"
+S.uncapitalize("BAR")
+
+// $ExpectType "foo"
+S.trim("   foo   ")
+
+// $ExpectType "foo"
+S.trim(`
+  \t     foo
+  \r\n
+`)
+
+// $ExpectType " foo"
+S.trimEnd(` foo
+  \r\n
+`)
+
+// $ExpectType "foo "
+S.trimStart(`
+   \r\n\t   foo `)
+
+
+// -----------------------------------------------------------------------------
+// types
+// -----------------------------------------------------------------------------
+
 type FooCapitalCase = "Foo"
 type BarCapitalCase = "Bar"
 type FooLowerCase = "foo"
@@ -16,7 +58,7 @@ export type BarToLowerCase = Lowercase<BarCapitalCase>
 // $ExpectType "Foo"
 export type FooCapitalized = Capitalize<FooLowerCase>
 
-// $ExpectType "Foo"
+// $ExpectType "bar"
 export type BarUncapitalized = Uncapitalize<BarCapitalCase>
 
 type LeadingSpaces = "   foo"

--- a/dtslint/String.ts
+++ b/dtslint/String.ts
@@ -1,0 +1,54 @@
+import * as S from '@effect/data/String'
+
+type FooCapitalCase = "Foo"
+type BarCapitalCase = "Bar"
+type FooLowerCase = "foo"
+
+// $ExpectType "FooBar"
+export type FooBarCapitalCase = S.Concat<FooCapitalCase, BarCapitalCase> 
+
+// $ExpectType "FOO"
+export type FooToUpperCase = Uppercase<FooLowerCase>
+
+// $ExpectType "bar"
+export type BarToLowerCase = Lowercase<BarCapitalCase>
+
+// $ExpectType "Foo"
+export type FooCapitalized = Capitalize<FooLowerCase>
+
+// $ExpectType "Foo"
+export type BarUncapitalized = Uncapitalize<BarCapitalCase>
+
+type LeadingSpaces = "   foo"
+type TrailingSpaces = "bar   "
+type LeadingAndTrailingSpaces = "   baz   "
+
+type NewLines = `
+      foo
+`
+
+type NewLinesAndTabs = `
+    \t\t  foo
+`
+
+type CarriageReturns = `
+  \r\n foo
+`
+
+// $ExpectType "foo"
+export type TrimLeadingSpaces = S.TrimStart<LeadingSpaces>
+
+// $ExpectType "bar"
+export type TrimTrailingSpaces = S.TrimEnd<TrailingSpaces>
+
+// $ExpectType "baz"
+export type TrimLeadingAndTrailingSpaces = S.Trim<LeadingAndTrailingSpaces>
+
+// $ExpectType "foo"
+export type TrimNewLines = S.Trim<NewLines>
+
+// $ExpectType "foo"
+export type TrimNewLinesAndTabs = S.Trim<NewLinesAndTabs>
+
+// $ExpectType "foo"
+export type TrimCarriageReturns = S.Trim<CarriageReturns>

--- a/src/String.ts
+++ b/src/String.ts
@@ -53,11 +53,20 @@ export const Order: order.Order<string> = order.string
 export const empty: "" = "" as const
 
 /**
+ * Concatenates two strings at the type level.
+ * 
+ * @since 1.0.0
+ */
+export type Concat<A extends string, B extends string> = `${A}${B}`
+
+/**
+ * Concatenates two strings at runtime.
+ * 
  * @since 1.0.0
  */
 export const concat: {
-  (that: string): (self: string) => string
-  (self: string, that: string): string
+  <B extends string>(that: B): <A extends string>(self: A) => Concat<A, B>
+  <A extends string, B extends string>(self: A, that: B): Concat<A, B>
 } = dual(2, (self: string, that: string): string => self + that)
 
 /**
@@ -69,7 +78,7 @@ export const concat: {
  *
  * @since 1.0.0
  */
-export const toUpperCase = (self: string): string => self.toUpperCase()
+export const toUpperCase = <S extends string>(self: S): Uppercase<S> => self.toUpperCase() as Uppercase<S>
 
 /**
  * @example
@@ -80,7 +89,37 @@ export const toUpperCase = (self: string): string => self.toUpperCase()
  *
  * @since 1.0.0
  */
-export const toLowerCase = (self: string): string => self.toLowerCase()
+export const toLowerCase = <T extends string>(self: T): Lowercase<T> => self.toLowerCase() as Lowercase<T>
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
+ *
+ * assert.deepStrictEqual(pipe('abc', S.capitalize), 'A')
+ *
+ * @since 1.0.0
+ */
+export const capitalize = <T extends string>(self: T): Capitalize<T> => {
+  if (self.length === 0) return self as Capitalize<T>
+
+  return (toUpperCase(self[0]) + self.slice(1)) as Capitalize<T>
+}
+
+/**
+ * @example
+ * import * as S from '@effect/data/String'
+ * import { pipe } from '@effect/data/Function'
+ *
+ * assert.deepStrictEqual(pipe('ABC', S.uncapitalize), 'aBC')
+ *
+ * @since 1.0.0
+ */
+export const uncapitalize = <T extends string>(self: T): Uncapitalize<T> => {
+  if (self.length === 0) return self as Uncapitalize<T>
+
+  return (toLowerCase(self[0]) + self.slice(1)) as Uncapitalize<T>
+}
 
 /**
  * @example
@@ -95,6 +134,11 @@ export const replace = (searchValue: string | RegExp, replaceValue: string) => (
   self.replace(searchValue, replaceValue)
 
 /**
+ * @since 1.0.0
+ */
+export type Trim<A extends string> = TrimEnd<TrimStart<A>>
+
+/**
  * @example
  * import * as S from '@effect/data/String'
  *
@@ -102,7 +146,20 @@ export const replace = (searchValue: string | RegExp, replaceValue: string) => (
  *
  * @since 1.0.0
  */
-export const trim = (self: string): string => self.trim()
+export const trim = <A extends string>(self: A): Trim<A> => self.trim() as Trim<A>
+
+/**
+ * @since 1.0.0
+ */
+export type TrimStart<A extends string> = A extends ` ${infer B}`
+  ? TrimStart<B>
+  : A extends `\n${infer B}`
+  ? TrimStart<B>
+  : A extends `\t${infer B}`
+  ? TrimStart<B>
+  : A extends `\r${infer B}`
+  ? TrimStart<B>
+  : A
 
 /**
  * @example
@@ -112,7 +169,20 @@ export const trim = (self: string): string => self.trim()
  *
  * @since 1.0.0
  */
-export const trimStart = (self: string): string => self.trimStart()
+export const trimStart = <A extends string>(self: A): TrimStart<A> => self.trimStart() as TrimStart<A>
+
+/**
+ * @since 1.0.0
+ */
+export type TrimEnd<A extends string> = A extends `${infer B} `
+  ? TrimEnd<B>
+  : A extends `${infer B}\n`
+  ? TrimEnd<B>
+  : A extends `${infer B}\t`
+  ? TrimEnd<B>
+  : A extends `${infer B}\r`
+  ? TrimEnd<B>
+  : A
 
 /**
  * @example
@@ -122,7 +192,7 @@ export const trimStart = (self: string): string => self.trimStart()
  *
  * @since 1.0.0
  */
-export const trimEnd = (self: string): string => self.trimEnd()
+export const trimEnd = <A extends string>(self: A): TrimEnd<A> => self.trimEnd() as TrimEnd<A>
 
 /**
  * @example

--- a/src/String.ts
+++ b/src/String.ts
@@ -54,14 +54,14 @@ export const empty: "" = "" as const
 
 /**
  * Concatenates two strings at the type level.
- * 
+ *
  * @since 1.0.0
  */
 export type Concat<A extends string, B extends string> = `${A}${B}`
 
 /**
  * Concatenates two strings at runtime.
- * 
+ *
  * @since 1.0.0
  */
 export const concat: {
@@ -151,14 +151,10 @@ export const trim = <A extends string>(self: A): Trim<A> => self.trim() as Trim<
 /**
  * @since 1.0.0
  */
-export type TrimStart<A extends string> = A extends ` ${infer B}`
-  ? TrimStart<B>
-  : A extends `\n${infer B}`
-  ? TrimStart<B>
-  : A extends `\t${infer B}`
-  ? TrimStart<B>
-  : A extends `\r${infer B}`
-  ? TrimStart<B>
+export type TrimStart<A extends string> = A extends ` ${infer B}` ? TrimStart<B>
+  : A extends `\n${infer B}` ? TrimStart<B>
+  : A extends `\t${infer B}` ? TrimStart<B>
+  : A extends `\r${infer B}` ? TrimStart<B>
   : A
 
 /**
@@ -174,14 +170,10 @@ export const trimStart = <A extends string>(self: A): TrimStart<A> => self.trimS
 /**
  * @since 1.0.0
  */
-export type TrimEnd<A extends string> = A extends `${infer B} `
-  ? TrimEnd<B>
-  : A extends `${infer B}\n`
-  ? TrimEnd<B>
-  : A extends `${infer B}\t`
-  ? TrimEnd<B>
-  : A extends `${infer B}\r`
-  ? TrimEnd<B>
+export type TrimEnd<A extends string> = A extends `${infer B} ` ? TrimEnd<B>
+  : A extends `${infer B}\n` ? TrimEnd<B>
+  : A extends `${infer B}\t` ? TrimEnd<B>
+  : A extends `${infer B}\r` ? TrimEnd<B>
   : A
 
 /**

--- a/src/String.ts
+++ b/src/String.ts
@@ -96,7 +96,7 @@ export const toLowerCase = <T extends string>(self: T): Lowercase<T> => self.toL
  * import * as S from '@effect/data/String'
  * import { pipe } from '@effect/data/Function'
  *
- * assert.deepStrictEqual(pipe('abc', S.capitalize), 'A')
+ * assert.deepStrictEqual(pipe('abc', S.capitalize), 'Abc')
  *
  * @since 1.0.0
  */

--- a/test/String.ts
+++ b/test/String.ts
@@ -59,6 +59,16 @@ describe.concurrent("String", () => {
     expect(S.toLowerCase("A")).toBe("a")
   })
 
+  it("capitalize", () => {
+    expect(S.capitalize("")).toBe("")
+    expect(S.capitalize("abc")).toBe("Abc")
+  })
+
+  it('uncapitalize', () => { 
+    expect(S.uncapitalize("")).toBe("")
+    expect(S.uncapitalize("Abc")).toBe("abc")
+  })
+
   it("replace", () => {
     expect(pipe("abc", S.replace("b", "d"))).toBe("adc")
   })

--- a/test/String.ts
+++ b/test/String.ts
@@ -64,7 +64,7 @@ describe.concurrent("String", () => {
     expect(S.capitalize("abc")).toBe("Abc")
   })
 
-  it('uncapitalize', () => { 
+  it("uncapitalize", () => {
     expect(S.uncapitalize("")).toBe("")
     expect(S.uncapitalize("Abc")).toBe("abc")
   })


### PR DESCRIPTION
I was looking through the docgen code, and noticed some usage of the `stripMargin` function which I had a need for recently and didn't know existed, which got me looking at the rest of the String module. 

Initially I noticed toUpperCase and toLowerCase could easily be improved with the built-ins from TS, I figure those are fairly safe to continue to add here. There's also `Capitalize` and `Uncapitalize` built-ins, so I went ahead and added corresponding functions for them.

I also started adding some type-level helpers for some of the easier things to replicate in string functionality. I'm less sure we'll wanna include these types of things in this lib, but I figured I'd open a PR for discussion about it.